### PR TITLE
resolve syntax error

### DIFF
--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -8,6 +8,7 @@ from typing import Optional
 from .QuantGenerationModel import QuantPreTrainedModel
 from .custom_symbolic_trace import custom_symbolic_trace
 from dataset import Dataset
+import copy
 
 
 gen_kwargs = {
@@ -79,7 +80,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
         org_model = None
     else:
         calib_dataloader = make_calib_dataloader(calib_dataset_path, model_script['calib_batch_size'], model.config.n_layer)
-        org_model = model if model_script["qlevel"]>=3 else None
+        org_model = copy.deepcopy(model) if model_script["qlevel"]>=3 else None
 
     
 
@@ -144,7 +145,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
 
     if org_model:
         model = model_compressor.create_quantsim_model(
-            model,
+            org_model,
             qformat_path = qformat_path,
             qparam_path = qparam_path,
             weight_calib_method=model_script["weight_calib_method"],


### PR DESCRIPTION
## 문제상황
- get_quant_model에서의 error 수정 

## 목적(해결방향)


## 구현 설명 Abstract
- deletedummy_fxg시 deepcopy를 수행하지 않으면 org_model을 quantsim으로 변환할때 error 발생 여부가 있음 

## 구현 설명 Detail (ex. 추가된 argument)


## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
  - language/gpt-j에서 `python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ.yaml --calib-dataset-path ./data/cnn_dailymail_calibration.json --gpu --accuracy --use_mcp' 실행 
  
 
## TODO (ex. 후속PR예고)


