### PR TITLE
add linear all

### DIFF
--- a/language/gpt-j/quantization/model_script/Qlevel1_RGDA0-W8A16-PTQ.yaml
+++ b/language/gpt-j/quantization/model_script/Qlevel1_RGDA0-W8A16-PTQ.yaml
@@ -13,3 +13,4 @@ weight_dtype: int8
 weight_granularity: channel
 weight_nbits: 8
 qlevel: 1 
+act_zp_equalizing: linear_all

--- a/language/gpt-j/quantization/model_script/Qlevel1_RGDA0-W8A8-PTQ-SMQ.yaml
+++ b/language/gpt-j/quantization/model_script/Qlevel1_RGDA0-W8A8-PTQ-SMQ.yaml
@@ -13,5 +13,7 @@ weight_dtype: int8
 weight_granularity: channel
 weight_nbits: 8
 qlevel: 1
-kv_dtype: int8
 autoscale: SmoothQuant
+autoscale_calib_method: auto
+smoothquant_alpha: 0.5
+act_zp_equalizing: linear_all

--- a/language/gpt-j/quantization/model_script/Qlevel1_RGDA0-W8A8KV8-PTQ.yaml
+++ b/language/gpt-j/quantization/model_script/Qlevel1_RGDA0-W8A8KV8-PTQ.yaml
@@ -14,3 +14,4 @@ weight_granularity: channel
 weight_nbits: 8
 qlevel: 1
 kv_dtype: int8
+act_zp_equalizing: linear_all

--- a/language/gpt-j/quantization/model_script/Qlevel2_RGDA0-W8A8KV8-PTQ.yaml
+++ b/language/gpt-j/quantization/model_script/Qlevel2_RGDA0-W8A8KV8-PTQ.yaml
@@ -14,3 +14,4 @@ weight_granularity: channel
 weight_nbits: 8
 qlevel: 2
 kv_dtype: int8
+act_zp_equalizing: linear_all

--- a/language/gpt-j/quantization/model_script/Qlevel3_RGDA0-W8A8KV8-PTQ.yaml
+++ b/language/gpt-j/quantization/model_script/Qlevel3_RGDA0-W8A8KV8-PTQ.yaml
@@ -14,3 +14,4 @@ weight_granularity: channel
 weight_nbits: 8
 qlevel: 3
 kv_dtype: int8
+act_zp_equalizing: linear_all

--- a/language/gpt-j/quantization/model_script/Qlevel4_RGDA0-W8A8-PTQ.yaml
+++ b/language/gpt-j/quantization/model_script/Qlevel4_RGDA0-W8A8-PTQ.yaml
@@ -1,6 +1,6 @@
 act_calib_method: MINMAX_ASYM
 act_dtype: int8
-act_granularity: channel
+act_granularity: tensor
 act_nbits: 8
 batch_size: 1
 calib_batch_size: 1
@@ -13,5 +13,4 @@ weight_dtype: int8
 weight_granularity: channel
 weight_nbits: 8
 qlevel: 4
-kv_dtype: int8
 act_zp_equalizing: linear_all

--- a/language/gpt-j/quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PERCENTILE-PTQ.yaml
+++ b/language/gpt-j/quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PERCENTILE-PTQ.yaml
@@ -14,3 +14,4 @@ weight_granularity: channel
 weight_nbits: 8
 qlevel: 4
 kv_dtype: int8
+act_zp_equalizing: linear_all


### PR DESCRIPTION
## 문제상황
- zp_equailizing이 model script에 빠져있음 

## 목적(해결방향)
- 해당 옵션을 추가 

## 구현 설명 Abstract

## 구현 설명 Detail (ex. 추가된 argument)


## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
  - language/gpt-j에서 `python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --calib-dataset-path ./data/cnn_dailymail_calibration.json --gpu --accuracy --use_mcp' 실행 
  
 
## TODO (ex. 후속PR예고)
- vLLM graph 추출

