### PR TITLE
fix bug:zp_eq

### DIFF
--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -79,7 +79,13 @@ def main():
     else:
         settings.mode = lg.TestMode.PerformanceOnly
     log_path = os.environ.get("LOG_PATH")
-    log_path = f"build/logs/{args.dataset_path.split('.')[1].split('/')[-1]}"
+    if args.model_script_path != "":
+        if "fp32" in args.model_script_path:
+            log_path = f"build/logs/fp32/{args.dataset_path.split('.')[1].split('/')[-1]}"
+        else:
+            log_path = f"build/logs/{args.model_script_path.split('.')[1].split('/')[-1]}/{args.dataset_path.split('.')[1].split('/')[-1]}"
+    else:
+        log_path = f"build/logs/{args.dataset_path.split('.')[1].split('/')[-1]}"
     if not log_path:
         log_path = "build/logs"
     if not os.path.exists(log_path):

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -136,7 +136,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
         act_nbits=model_script["act_nbits"],
         qlevel=model_script["qlevel"],
         target_machine=model_script["target_machine"],
-        act_zp_equalizing=(model_script["act_zp_equalizing"] if run_autoscale else 'disabled'),
+        act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
         dataloader=calib_dataloader,
         disable_inout=(True, True),
         kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16'
@@ -157,7 +157,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             act_nbits=model_script["act_nbits"],
             percentile=model_script["percentile"],
             target_machine=model_script["target_machine"],
-            act_zp_equalizing=(model_script["act_zp_equalizing"] if run_autoscale else 'disabled'),
+            act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
             autoscale=model_script["autoscale"] if run_autoscale else "disabled",
             autoscale_calib_method=(model_script["autoscale_calib_method"] if run_autoscale else 'auto'),
             autoscale_calib_kwargs=autoscale_calib_cfg if run_autoscale else None,
@@ -197,7 +197,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             act_nbits=model_script["act_nbits"],
             qlevel=model_script["qlevel"],
             target_machine=model_script["target_machine"],
-            act_zp_equalizing=(model_script["act_zp_equalizing"] if run_autoscale else 'disabled'),
+            act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
             dataloader=None,
             disable_inout=(True, True),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16'


### PR DESCRIPTION
## 문제상황
- create_quantsim_model 의 act_zp_equalizing 옵션이 제대로 입력되지 않음

## 목적(해결방향)
- script 에 act_zp_equalizing 항목이 있으면 동작하도록 변경

## 구현 설명 Abstract
- script 에 act_zp_equalizing 항목이 있으면 동작하도록 변경

## 구현 설명 Detail (ex. 추가된 argument)
- script 에 act_zp_equalizing 항목이 있으면 동작하도록 변경

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `python run/run_massive_test.py --machine_type WBYA0 --batch_size 1 --ci`

## TODO (ex. 후속PR예고)
- 

