### PR TITLE
Split run mode 추가

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -19,7 +19,7 @@ gen_kwargs = {
 
 
 class SUT_base():
-    def __init__(self, model_path, dtype, dataset_path, max_examples, use_gpu=False):
+    def __init__(self, model_path, dtype, dataset_path, max_examples, use_gpu=False, num_splits=1, split_idx=0):
         # TODO : Pass model file name to init instead of args
         print("Loading PyTorch model...")
         self.model_name = "EleutherAI/gpt-j-6B"
@@ -63,7 +63,7 @@ class SUT_base():
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
         self.data_object = Dataset(
-            self.dataset_path, total_count_override=max_examples)
+            self.dataset_path, total_count_override=max_examples, num_splits=num_splits, split_idx=split_idx)
         self.qsl = lg.ConstructQSL(self.data_object.count, self.data_object.perf_count,
                                    self.data_object.LoadSamplesToRam, self.data_object.UnloadSamplesFromRam)
 
@@ -130,8 +130,8 @@ class SUT_base():
 
 
 class SUT_Offline(SUT_base):
-    def __init__(self, model_path, dtype, dataset_path, max_examples, use_gpu):
-        SUT_base.__init__(self, model_path, dtype, dataset_path, max_examples, use_gpu)
+    def __init__(self, model_path, dtype, dataset_path, max_examples, use_gpu, num_splits, split_idx):
+        SUT_base.__init__(self, model_path, dtype, dataset_path, max_examples, use_gpu, num_splits, split_idx)
     '''IssueQuery and inference methods implemented in Base class'''
 
 
@@ -193,9 +193,9 @@ class SUT_SingleStream(SUT_base):
             print("Completed : ", self.total_samples_done)
 
 
-def get_SUT(model_path, scenario, dtype, dataset_path, max_examples, use_gpu=False):
+def get_SUT(model_path, scenario, dtype, dataset_path, max_examples, use_gpu=False, num_splits=1, split_idx=0):
     if scenario == "Offline":
-        return SUT_Offline(model_path, dtype, dataset_path, max_examples, use_gpu)
+        return SUT_Offline(model_path, dtype, dataset_path, max_examples, use_gpu, num_splits, split_idx)
     elif scenario == "Server":
         return SUT_Server(model_path, dtype, dataset_path, max_examples, use_gpu)
     elif scenario == "SingleStream":

--- a/language/gpt-j/dataset.py
+++ b/language/gpt-j/dataset.py
@@ -26,7 +26,7 @@ PROMPT_DICT = {
 
 
 class Dataset():
-    def __init__(self, dataset_path, batch_size=1, pad_val=1, pad_max=196, total_count_override=None, perf_count_override=None):
+    def __init__(self, dataset_path, batch_size=1, pad_val=1, pad_max=196, total_count_override=None, perf_count_override=None, num_splits=1, split_idx=0):
         print("Constructing QSL")
 
         self.dataset = "cnn_dailymail"
@@ -44,6 +44,9 @@ class Dataset():
         self.tokenizer.pad_token = self.tokenizer.eos_token
 
         self.list_data_dict = utils.jload(self.dataset_path)
+        if num_splits > 1:
+            n_splited_data = int(len(self.list_data_dict)/num_splits)
+            self.list_data_dict = self.list_data_dict[split_idx*n_splited_data:(split_idx+1)*n_splited_data]
 
         prompt_input, prompt_no_input = PROMPT_DICT["prompt_input"], PROMPT_DICT["prompt_no_input"]
         self.sources = [prompt_input.format_map(

--- a/language/gpt-j/evaluation_split_mode.py
+++ b/language/gpt-j/evaluation_split_mode.py
@@ -1,0 +1,129 @@
+from dataset import Dataset
+import os
+import time
+import numpy as np
+import json
+import nltk
+import array
+import torch
+from torch.nn.functional import pad
+from torch.utils.data import DataLoader
+import evaluate
+import argparse
+import nltk
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import yaml,pdb
+
+def get_args():
+    """Parse commandline."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_script_name", required=True,
+                        help="path to mlperf_log_accuracy.json")
+    parser.add_argument("--dataset-file", required=True,
+                        help="path to cnn_eval.json")
+    parser.add_argument("--verbose", action="store_true",
+                        help="verbose messages")
+    parser.add_argument("--dtype", default="int64",
+                        help="dtype of the accuracy log", choices=["int32", "int64"])
+    parser.add_argument("--num_splits", type=int, default=1, 
+                        help="")
+    args = parser.parse_args()
+    return args
+
+
+def postprocess_text(preds, targets):
+    preds = [pred.strip() for pred in preds]
+    targets = [target.strip() for target in targets]
+
+    # rougeLSum expects newline after each sentence
+    preds = ["\n".join(nltk.sent_tokenize(pred)) for pred in preds]
+    targets = ["\n".join(nltk.sent_tokenize(target)) for target in targets]
+
+    return preds, targets
+
+
+def main():
+
+    args = get_args()
+    model_name = "EleutherAI/gpt-j-6B"
+    dataset_path = args.dataset_file
+    metric = evaluate.load("rouge")
+    nltk.download('punkt')
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name,
+        model_max_length=2048,
+        padding_side="left",
+        use_fast=False,)
+    tokenizer.pad_token = tokenizer.eos_token
+
+    data_object = Dataset(dataset_path)
+    targets = data_object.targets
+
+    root_logdir = os.path.join('./build/logs', args.model_script_name)
+    default_log_name="mlperf_log_accuracy.json"
+    results_path_list = []
+    for idx in range(args.num_splits):
+        results_path_list.append(os.path.join(root_logdir, f"{args.dataset_file.split('.')[1].split('/')[-1]}_{args.num_splits}_{idx}"))
+        
+    
+
+    results = []
+
+    for result_path in results_path_list:
+        with open(os.path.join(result_path, default_log_name), "r") as f:
+            result = json.load(f)
+            results.append(result)
+        
+
+    n_splited_data=len(results[0])
+
+    # Deduplicate the results loaded from the json
+    dedup_results = []
+    seen = set()
+    for idx, split_result in enumerate(results):
+        for result in split_result:
+            item = result['qsl_idx'] + n_splited_data*idx
+            if item not in seen:
+                seen.add(item)
+                result['qsl_idx'] = item
+                dedup_results.append(result)
+
+
+
+    results = dedup_results      
+
+    target_required = []
+    preds_token_ids = []
+
+    eval_dtype = np.int64
+    if args.dtype == "int32":
+        eval_dtype = np.int32
+
+    for pred in results:
+        qsl_idx = pred['qsl_idx']
+        target = targets[qsl_idx]
+        target_required.append(target)
+        preds_token_ids.append(np.frombuffer(
+            bytes.fromhex(pred['data']), eval_dtype))
+
+    preds_decoded_text = tokenizer.batch_decode(
+        preds_token_ids, skip_special_tokens=True)
+
+    preds, targets = postprocess_text(preds_decoded_text, target_required)
+
+    result = metric.compute(
+        predictions=preds, references=targets, use_stemmer=True, use_aggregator=False)
+    name = dataset_path.split('.')[1].split('/')[-1]
+    # with open(f'result_qlevel_4_{name}.yaml', 'w') as file:
+    #     yaml.dump(result, file)
+    result = {k: round(np.mean(v) * 100, 4) for k, v in result.items()}
+    prediction_lens = [len(pred) for pred in preds]
+    result["gen_len"] = np.sum(prediction_lens)
+    result["gen_num"] = len(preds)
+    print("\nResults\n")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -65,6 +65,8 @@ def main():
         dataset_path=args.dataset_path,
         max_examples=args.max_examples,
         use_gpu=args.gpu,
+        num_splits=args.num_splits,
+        split_idx=args.split_idx
     )
 
     if args.use_mcp:

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -82,10 +82,16 @@ def main():
         settings.mode = lg.TestMode.PerformanceOnly
     log_path = os.environ.get("LOG_PATH")
     if args.model_script_path != "":
-        if "fp32" in args.model_script_path:
-            log_path = f"build/logs/fp32/{args.dataset_path.split('.')[1].split('/')[-1]}"
+        if "fp32" in args.model_script_path or args.use_mcp == False:
+            if args.num_splits > 1:
+                log_path = f"build/logs/fp32/{args.dataset_path.split('.')[1].split('/')[-1]}_{args.num_splits}_{args.split_idx}"
+            else:
+                log_path = f"build/logs/fp32/{args.dataset_path.split('.')[1].split('/')[-1]}"
         else:
-            log_path = f"build/logs/{args.model_script_path.split('.')[1].split('/')[-1]}/{args.dataset_path.split('.')[1].split('/')[-1]}"
+            if args.num_splits > 1:
+                log_path = f"build/logs/{args.model_script_path.split('.')[1].split('/')[-1]}/{args.dataset_path.split('.')[1].split('/')[-1]}_{args.num_splits}_{args.split_idx}"
+            else:
+                log_path = f"build/logs/{args.model_script_path.split('.')[1].split('/')[-1]}/{args.dataset_path.split('.')[1].split('/')[-1]}"
     else:
         log_path = f"build/logs/{args.dataset_path.split('.')[1].split('/')[-1]}"
     if not log_path:

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -41,6 +41,8 @@ def get_args():
     parser.add_argument("--model_script_path", default="./quantization/model_script/Qlevel1_RGDA0-W8A16-PTQ.yaml", help="")
     parser.add_argument("--use_mcp", action="store_true", default=False, help="use mcp to quantize the model")
     parser.add_argument("--recalibrate", action="store_true", default=False, help="load already existing quantization metadata")
+    parser.add_argument("--num_splits", type=int, default=1, help="")
+    parser.add_argument("--split_idx", type=int, default=0, help="")
     args = parser.parse_args()
     return args
 

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -39,7 +39,7 @@ def get_args():
     parser.add_argument("--max_examples", type=int, default=None,
                         help="Maximum number of examples to consider (not limited by default)")
     parser.add_argument("--model_script_path", default="./quantization/model_script/Qlevel1_RGDA0-W8A16-PTQ.yaml", help="")
-    parser.add_argument("--use_mcp", action="store_true", help="use mcp to quantize the model")
+    parser.add_argument("--use_mcp", action="store_true", default=False, help="use mcp to quantize the model")
     parser.add_argument("--recalibrate", action="store_true", default=False, help="load already existing quantization metadata")
     args = parser.parse_args()
     return args


### PR DESCRIPTION
## 문제상황
- 현재는 데이터를 나눠놓고 run 하도록 되어있는데 resource 에 따라 유동적으로 실험하기 위함

## 목적(해결방향)
- split run 모드 구현

## 구현 설명 Abstract
- num_splits: 몇 개의 resource 를 사용할지 지정
- split_idx: split run 중 몇 번째인지 지정  
- 위의 args 를 입력하고 돌리는 경우에 args.dataset-path 에 입력한 dataset 을 load 한 다음 나누고 지정한 순번의 run 을 실행함
- 입력한 model_script, num_splits, split_idx 에 따라 결과 log dir 를 만듦
- evaluation_split_mode.py 는 위 split run 에서 사용한 model_scipt_name 과 num_splits, split_idx 를 입력하면 합쳐서 rouge score 를 계산함

## 구현 설명 Detail (ex. 추가된 argument)
- split run 결과는 ./build/logs/{model_script_name}/{dataset_name}_{num_splits}_{split_idx}/mlperf_log_accuracy.json 에 저장됨
- evaluation_split_mode 할 때는 split_idx 와 각 결과의 qsl_idx 로 원래 전체 dataset 에서의 qsl_idx 를 유추할 수 있음, 이 방법으로 합쳐서 rouge score 를 계산함

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
- split run
- `python main.py --model-path ./model/ --gpu --accuracy --use_mcp --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-zp_eq-PTQ.yaml --num_splits 4 --dataset-path ./data/cnn_eval_accuracy_ci.json --split_idx 0`
- `python main.py --model-path ./model/ --gpu --accuracy --use_mcp --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-zp_eq-PTQ.yaml --num_splits 4 --dataset-path ./data/cnn_eval_accuracy_ci.json --split_idx 1`...
- evaluation_split_mode
- `python evaluation_split_mode.py --dataset-file ./data/cnn_eval_accuracy_ci.json --model_script_name Qlevel4_RGDA0-W8A8KV8-zp_eq-PTQ --num_splits 4`

## TODO (ex. 후속PR예고)
- 

