### PR TITLE
stratified sampling of eval data

### DIFF
--- a/language/gpt-j/stratified_sampling.py
+++ b/language/gpt-j/stratified_sampling.py
@@ -1,0 +1,83 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import yaml
+import numpy as np
+import random
+import json 
+
+rouge = []
+eval_data = []
+acc_log = []
+num_part = 4
+
+for i in range(num_part):
+    rouge_yaml_file_name = 'result_qlevel_4_cnn_eval_part_' + str(i) + '.yaml'
+    json_file = open('data/cnn_eval_part_' + str(i) + '.json')
+    log_file = open('build/logs/cnn_eval_part_' + str(i) + '_qlevel4_minmax' +  '/mlperf_log_accuracy.json')
+    summary_file = 'summary_target_qlevel4_cnn_eval_part_' + str(i) + '.yaml'
+    
+    with open(rouge_yaml_file_name) as f:
+        rouge_per_part = yaml.load(f, Loader=yaml.FullLoader)
+    eval_data.append(json.load(json_file))
+    acc_log.append(json.load(log_file))
+    rouge.append(rouge_per_part)
+    
+
+
+
+total_rouge = {'rouge1': [],
+               'rouge2': [],
+               'rougeL': [],
+               'rougeLsum': [],
+               }
+
+for i in range(len(rouge)):
+    for key, value in rouge[i].items():
+        total_rouge[key] += value
+    
+total_data_len = len(total_rouge['rouge2'])
+data_per_part = int(total_data_len / num_part)
+
+
+bins = np.linspace(0.0,1.0,5)
+
+rouge_1 = total_rouge['rouge1']
+rouge_2 = total_rouge['rouge2']
+rouge_L = total_rouge['rougeL']
+
+
+rouge_2_dict = {k:v for v, k in enumerate(rouge_2)}
+rouge_2.sort()
+    
+hist_rouge_1, _ = np.histogram(rouge_1, bins)
+hist_rouge_2, bin_edges = np.histogram(rouge_2, bins)
+hist_rouge_L, _ = np.histogram(rouge_L, bins)
+plt.plot(bins[:-1], hist_rouge_1)
+plt.plot(bins[:-1], hist_rouge_2)
+plt.plot(bins[:-1], hist_rouge_L)
+
+
+percentage_per_beam  = hist_rouge_2/hist_rouge_2.sum()
+
+sampled_data = []
+index_sampled_data=[]
+sample_size = 100 
+plt.show()
+
+for i in range(len(hist_rouge_2)):
+    bin_samples = random.sample(rouge_2[0:hist_rouge_2[i]-1], int(percentage_per_beam[i]*sample_size))    
+    # Append the samples to the overall list
+    rouge_2 = rouge_2[hist_rouge_2[i]:]
+    sampled_data.extend(bin_samples)
+    index_sampled_data = index_sampled_data + [rouge_2_dict[num] for num in bin_samples]
+
+stratified_eval_data = []
+for selected_idx in index_sampled_data:
+    qsl_idx = acc_log[selected_idx//data_per_part][selected_idx % data_per_part]['qsl_idx']
+    stratified_eval_data.append(eval_data[selected_idx//data_per_part][qsl_idx])
+    
+    
+with open('./data/stratified_eval_data.json', 'w') as json_file:
+    json.dump(stratified_eval_data, json_file, indent='\t', separators=(',', ': '))
+
+


### PR DESCRIPTION
## 문제상황
- MLperf evaluation test가 너무 오래 걸리기 때문에, calib method나 hyperparameter tuning등에 대한 효과를 확인하기가 번거로움

## 목적(해결방향)
- Full test 와 비슷한 성능을 낼 수 있는 eval_ci 추출

## 구현 설명 Abstract

## 구현 설명 Detail (ex. 추가된 argument)


## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
- 'python stratified_sampling.py'
  - language/gpt-j에서 `python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/.stratified_eval_datajson --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --calib-dataset-path ./data/cnn_dailymail_calibration.json --gpu --accuracy --use_mcp' 실행 
  
 
## TODO (ex. 후속PR예고)
- vLLM graph 추출

