### PR TITLE
Smq scale factor merge 방향 설정 추가, zp_eq 버그 fix

### DIFF
--- a/language/gpt-j/evaluation_split_mode.py
+++ b/language/gpt-j/evaluation_split_mode.py
@@ -19,7 +19,7 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_script_name", required=True,
                         help="path to mlperf_log_accuracy.json")
-    parser.add_argument("--dataset-file", required=True,
+    parser.add_argument("--dataset-file", default="./data/cnn_eval.json",
                         help="path to cnn_eval.json")
     parser.add_argument("--verbose", action="store_true",
                         help="verbose messages")

--- a/language/gpt-j/quantization/autoscale/extract_kwargs.py
+++ b/language/gpt-j/quantization/autoscale/extract_kwargs.py
@@ -79,6 +79,8 @@ def get_autoscale_calib_cfg(
     if args.unify_smooth_factor and not isinstance(model, GPTJForCausalLM):
         raise ValueError("In current, unifying smooth factor feature only supports GPT-J.")
     calib_cfg['unify_smooth_factor'] = args.unify_smooth_factor
+    calib_cfg['module_name_to_replace_smooth_factor'] = args.module_name_to_replace_smooth_factor
+    calib_cfg['module_name_for_smooth_factor'] = args.module_name_for_smooth_factor
 
     return calib_cfg
 

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -105,22 +105,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
     else:
         org_model = None
     
-
-     
-        
-    # if os.path.exists(qformat_path) and os.path.exists(qparam_path) and recalibrate == False:
-    #     calib_dataloader = None
-    #     org_model = None
-    # else:
-    #     calib_dataloader = make_calib_dataloader(calib_dataset_path, model_script['calib_batch_size'], model.config.n_layer)
-    #     org_model = model if model_script["qlevel"]>=3 else None
-
-    #    #prepare for autoscale 
-
-  
-
-
-        
     # Extract necessary parameters to initialize QuantPreTrainedModel
     model = model_compressor.create_quantsim_model(
         model,
@@ -136,7 +120,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
         act_nbits=model_script["act_nbits"],
         qlevel=model_script["qlevel"],
         target_machine=model_script["target_machine"],
-        act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
+        act_zp_equalizing=model_script["act_zp_equalizing"] if  "act_zp_equalizing" in model_script else 'disabled',
         dataloader=calib_dataloader,
         disable_inout=(True, True),
         kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16'
@@ -157,7 +141,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             act_nbits=model_script["act_nbits"],
             percentile=model_script["percentile"],
             target_machine=model_script["target_machine"],
-            act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
+            act_zp_equalizing=model_script["act_zp_equalizing"] if  "act_zp_equalizing" in model_script else 'disabled',
             autoscale=model_script["autoscale"] if run_autoscale else "disabled",
             autoscale_calib_method=(model_script["autoscale_calib_method"] if run_autoscale else 'auto'),
             autoscale_calib_kwargs=autoscale_calib_cfg if run_autoscale else None,
@@ -197,7 +181,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             act_nbits=model_script["act_nbits"],
             qlevel=model_script["qlevel"],
             target_machine=model_script["target_machine"],
-            act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
+            act_zp_equalizing=model_script["act_zp_equalizing"] if  "act_zp_equalizing" in model_script else 'disabled',
             dataloader=None,
             disable_inout=(True, True),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16'


### PR DESCRIPTION
- 수정사항
  - SMQ scale factor 를 qkv->fc_in or fc_in->qkv 가능하게 변경된 mcp 를 적용가능하게 변경
  - script 에 zp_eq 없을 때 오류 발생하는 상황에 대한 버그 fix
  - eval_split_run 에 default dataset 설정