### PR TITLE
Port furiosa-llm & separate GPT-J graphs

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -140,7 +140,7 @@ class SUT_base():
 
 
 class SUT_Offline(SUT_base):
-    def __init__(self, model_path, dtype, dataset_path, max_examples,  use_gpu, num_splits, split_idx, model_source):
+    def __init__(self, model_path, dtype, dataset_path, max_examples, use_gpu, num_splits, split_idx, model_source):
         SUT_base.__init__(self, model_path, dtype, dataset_path, max_examples, use_gpu, num_splits, split_idx, model_source)
     '''IssueQuery and inference methods implemented in Base class'''
 

--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -41,8 +41,11 @@ class SUT_base():
             
         if model_source == 'transformers':
             model_cls = AutoModelForCausalLM
-        elif model_source == 'furiosa_llm':
+        elif model_source == 'furiosa_llm_original':
             from furiosa_llm_models.models.gptj.modeling_gptj import GPTJForCausalLM
+            model_cls = GPTJForCausalLM
+        elif model_source == 'furiosa_llm_paged_attention':
+            from furiosa_llm_models.models.gptj.modeling_gptj_paged_attention_concat import GPTJForCausalLM
             model_cls = GPTJForCausalLM
         
         self.model = model_cls.from_pretrained(
@@ -51,6 +54,7 @@ class SUT_base():
             low_cpu_mem_usage=True if not self.use_gpu else False,
             torch_dtype=self.amp_dtype
         )
+        
 
         # Cast the model to GPU if the flag is set.
         if self.use_gpu:
@@ -112,7 +116,6 @@ class SUT_base():
             input_batch = dict()
             input_batch['input_ids'] = input_ids_tensor
             input_batch['attention_mask'] = input_masks_tensor
-
             output_batch = self.model.generate(
                 **input_batch, **gen_kwargs, pad_token_id=self.tokenizer.eos_token_id)
 

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -47,6 +47,7 @@ def get_args():
     parser.add_argument("--num_splits", type=int, default=1, help="")
     parser.add_argument("--split_idx", type=int, default=0, help="")
     parser.add_argument('--torch_optim',default='default',type=str,choices=['default', 'none'],help='Torch optimization.',)
+    parser.add_argument("--model_source", type = str, default = "transformers", help="the type of GPTJForCausalLM to use")
     args = parser.parse_args()
     return args
 
@@ -62,9 +63,6 @@ scenario_map = {
 def main():
     args = get_args()
 
-    set_optimization(args)
-    random_seed()
-
     sut = get_SUT(
         model_path=args.model_path,
         scenario=args.scenario,
@@ -73,7 +71,8 @@ def main():
         max_examples=args.max_examples,
         use_gpu=args.gpu,
         num_splits=args.num_splits,
-        split_idx=args.split_idx
+        split_idx=args.split_idx,
+        model_source = args.model_source,
     )
 
     if args.use_mcp:

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -62,7 +62,8 @@ scenario_map = {
 
 def main():
     args = get_args()
-
+    set_optimization(args)
+    random_seed()
     sut = get_SUT(
         model_path=args.model_path,
         scenario=args.scenario,
@@ -77,7 +78,8 @@ def main():
 
     if args.use_mcp:
         sut.model = quantization.get_quant_model(sut.model, args.calib_dataset_path, args.model_script_path, args.recalibrate)
-    
+    import pdb
+    pdb.set_trace()
     settings = lg.TestSettings()
     settings.scenario = scenario_map[args.scenario]
     # Need to update the conf

--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -78,8 +78,7 @@ def main():
 
     if args.use_mcp:
         sut.model = quantization.get_quant_model(sut.model, args.calib_dataset_path, args.model_script_path, args.recalibrate)
-    import pdb
-    pdb.set_trace()
+
     settings = lg.TestSettings()
     settings.scenario = scenario_map[args.scenario]
     # Need to update the conf

--- a/language/gpt-j/quantization/autoscale/transform_descriptor_utils.py
+++ b/language/gpt-j/quantization/autoscale/transform_descriptor_utils.py
@@ -20,6 +20,7 @@ def _define_transform_descriptor_from_model_type(
     from transformers.models.opt.modeling_opt import OPTForCausalLM
     from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
     from transformers.models.bert.modeling_bert import BertForQuestionAnswering
+    from furiosa_llm_models.models.gptj.modeling_gptj import GPTJForCausalLM as GPTJForCausalLM_furiosa
 
     if_autoscale_postprocessor = not if_autoscale_preprocessor
     transform_descriptor = []
@@ -28,12 +29,13 @@ def _define_transform_descriptor_from_model_type(
         isinstance(model, OPTForCausalLM)
         or isinstance(model, LlamaForCausalLM)
         or isinstance(model, GPTJForCausalLM)
+        or isinstance(model, GPTJForCausalLM_furiosa)
     ):
         if isinstance(model, OPTForCausalLM):
             _model_type = 'OPTForCausalLM'
         elif isinstance(model, LlamaForCausalLM):
             _model_type = 'LlamaForCausalLM'
-        elif isinstance(model, GPTJForCausalLM):
+        elif isinstance(model, GPTJForCausalLM) or isinstance(model, GPTJForCausalLM_furiosa):
             _model_type = 'GPTJForCausalLM'
 
         if if_autoscale_preprocessor:
@@ -158,6 +160,8 @@ def load_predefined_settings(
     from transformers.models.opt.modeling_opt import OPTForCausalLM
     from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
     from transformers.models.bert.modeling_bert import BertForQuestionAnswering
+    from furiosa_llm_models.models.gptj.modeling_gptj import GPTJForCausalLM as GPTJForCausalLM_furiosa
+    
     preprocessor = []
     postprocessor = []
 
@@ -166,6 +170,7 @@ def load_predefined_settings(
         or isinstance(model, LlamaForCausalLM)
         or isinstance(model, GPTJForCausalLM)
         or isinstance(model, BertForQuestionAnswering)
+        or isinstance(model, GPTJForCausalLM_furiosa)
     ):
         preprocessor.extend(
             _define_transform_descriptor_from_model_type(

--- a/language/gpt-j/quantization/custom_symbolic_trace.py
+++ b/language/gpt-j/quantization/custom_symbolic_trace.py
@@ -12,13 +12,11 @@ def get_input_names_and_concrete_args(model: PreTrainedModel, prefill_mode = Tru
         raise NotImplementedError
     
     #defined according to MLperf models
+    custom_concrete_args = {'use_cache': True, 'return_dict': True,
+                                    'output_attentions': False, 'output_hidden_states': False}
     if prefill_mode:
-        custom_concrete_args = {'use_cache': False, 'return_dict': True,
-                                    'output_attentions': False, 'output_hidden_states': False} 
         input_names = ["input_ids", "position_ids", "attention_mask"]
     else:
-        custom_concrete_args = {'use_cache': True, 'return_dict': True,
-                                    'output_attentions': False, 'output_hidden_states': False}
         input_names = ["input_ids", "past_key_values", "position_ids", "attention_mask"]
         
 

--- a/language/gpt-j/quantization/custom_symbolic_trace.py
+++ b/language/gpt-j/quantization/custom_symbolic_trace.py
@@ -39,7 +39,7 @@ def get_input_names_and_concrete_args(model: PreTrainedModel, prefill_mode = Tru
 def custom_symbolic_trace(model: PreTrainedModel, prefill_mode = True, disable_check: bool = False) -> GraphModule:
     
     input_names, concrete_args = get_input_names_and_concrete_args(model, prefill_mode)
-
+    
     if not disable_check:
         check_if_model_is_supported(model)
 

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -9,6 +9,7 @@ from .QuantPreTrainedModel import QuantPreTrainedModel
 from .custom_symbolic_trace import custom_symbolic_trace
 from dataset import Dataset
 import copy
+import pdb
 
 
 
@@ -97,8 +98,13 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
  
         
     model_type = type(model)
-    model, input_names, concrete_args = custom_symbolic_trace(model)
-    
+    module = type(model).__module__.split('.')[0]
+    if module == 'transformers':
+        model, input_names, concrete_args = custom_symbolic_trace(model, prefill_mode = False)
+    elif module =='furiosa_llm_models':
+        prefill_model, input_names_prefill, concrete_args_prefill = custom_symbolic_trace(model, prefill_mode = True)
+        decode_model, input_names_decode, concrete_args_decode = custom_symbolic_trace(model, prefill_mode = False)
+    pdb.set_trace()
     if calib_dataloader is not None and model_script["qlevel"] > 2:
         org_model = copy.deepcopy(model)
         org_model.config = model.config

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -239,6 +239,5 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
         "prefill_model": prefill_model,
         "decode_model": decode_model,
     }
-    import pdb
-    pdb.set_trace()
+
     return model_compressor.helper.QuantCausalLM(quant_models, model_type, input_names, concrete_args)

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -9,7 +9,6 @@ from .QuantPreTrainedModel import QuantPreTrainedModel
 from .custom_symbolic_trace import custom_symbolic_trace
 from dataset import Dataset
 import copy
-import pdb
 
 
 

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -84,7 +84,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
     qformat_path = f"./quantization/output/qformat_{model_script_path.split('.')[1].split('/')[-1]}.yaml" 
     qparam_path = f"./quantization/output/qparam_{model_script_path.split('.')[1].split('/')[-1]}.npy"
     
-    
     if os.path.exists(qformat_path) and os.path.exists(qparam_path) and recalibrate == False:
         calib_dataloader = None
     else:

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -112,19 +112,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
     }
 
 
-    # if calib_dataloader is not None and model_script["qlevel"] > 2:
-    #     org_prefill_model = copy.deepcopy(prefill_model)
-    # if os.path.exists(qformat_path) and os.path.exists(qparam_path) and recalibrate == False:
-    #     calib_dataloader = None
-    #     org_model = None
-    # else:
-    #     calib_dataloader = make_calib_dataloader(calib_dataset_path, model_script['calib_batch_size'], model.config.n_layer)
-    #     org_model = model if model_script["qlevel"]>=3 else None
-
-    #    #prepare for autoscale 
-
-  
-
     if calib_dataloader:
         prefill_model_for_calib = copy.deepcopy(prefill_model)
         # Extract necessary parameters to initialize QuantPreTrainedModel

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -98,13 +98,10 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
  
         
     model_type = type(model)
-    module = type(model).__module__.split('.')[0]
-    if module == 'transformers':
-        model, input_names, concrete_args = custom_symbolic_trace(model, prefill_mode = False)
-    elif module =='furiosa_llm_models':
-        prefill_model, input_names_prefill, concrete_args_prefill = custom_symbolic_trace(model, prefill_mode = True)
-        decode_model, input_names_decode, concrete_args_decode = custom_symbolic_trace(model, prefill_mode = False)
-    pdb.set_trace()
+
+    prefill_model, input_names_prefill, concrete_args_prefill = custom_symbolic_trace(model, prefill_mode = True)
+    decode_model, input_names_decode, concrete_args_decode = custom_symbolic_trace(model, prefill_mode = False)
+
     if calib_dataloader is not None and model_script["qlevel"] > 2:
         org_model = copy.deepcopy(model)
         org_model.config = model.config


### PR DESCRIPTION
## 문제상황
- prefill_model과 decode_model를 별도로 생성해야함
- furiosa-llm이 transformers-compression의 model과 동치인지를 확인해야함

## 목적(해결방향)
- prefill model & decode model 별도로 생성
- furiosa_llm을 inference compression에서 사용 

## 구현 설명 Abstract
-model_source argument를 정의함 (transformers, furiosa_llm_original, furiosa_llm_paged_attention 등 다양한 gpt-j 모델을 사용 가능하도록 함)
-Smoothquant를 furiosa_llm.GPTJforCausalLM 에 적용


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

