### PR TITLE
Fix furiosa llm rope

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -48,7 +48,7 @@ class SUT_base():
             from furiosa_llm_models.gptj.paged_attention_concat import GPTJForCausalLM 
             model_cls = GPTJForCausalLM
         elif model_source == 'furiosa_llm_rope':
-            from furiosa_llm_models.models.gptj.huggingface_rope import GPTJForCausalLM
+            from furiosa_llm_models.gptj.huggingface_rope import GPTJForCausalLM
             model_cls = GPTJForCausalLM
         
         self.model = model_cls.from_pretrained(

--- a/language/gpt-j/quantization/autoscale/extract_kwargs.py
+++ b/language/gpt-j/quantization/autoscale/extract_kwargs.py
@@ -13,6 +13,7 @@ from transformers.models.llama.modeling_llama import LlamaAttention, LlamaForCau
 from transformers.models.opt.modeling_opt import OPTAttention, OPTForCausalLM
 from transformers.models.gptj.modeling_gptj import GPTJAttention, GPTJForCausalLM
 from furiosa_llm_models.gptj.huggingface import GPTJForCausalLM as GPTJForCausalLM_furiosa
+from furiosa_llm_models.gptj.huggingface_rope import GPTJForCausalLM as GPTJForCausalLM_rope
 from transformers.models.bert.modeling_bert import BertForQuestionAnswering
 
 __all__ = ["get_autoscale_calib_cfg", "valid_check_calib_cfg"]
@@ -77,7 +78,7 @@ def get_autoscale_calib_cfg(
         )
     calib_cfg['nodes_excluded_from_auto_clip_calib'] = args.nodes_excluded_from_auto_clip_calib
 
-    if args.unify_smooth_factor and type(model) not in [GPTJForCausalLM, GPTJForCausalLM_furiosa]:
+    if args.unify_smooth_factor and type(model) not in [GPTJForCausalLM, GPTJForCausalLM_furiosa, GPTJForCausalLM_rope]:
         raise ValueError("Unifying smoothing factor is implemented only for GPT-J at the moment.")
     calib_cfg['unify_smooth_factor'] = args.unify_smooth_factor
     calib_cfg['module_name_to_replace_smooth_factor'] = args.module_name_to_replace_smooth_factor
@@ -173,7 +174,7 @@ def _get_predefined_excluded_from_auto_scale_calib(torch_model, autoscale):
             nodes_list = ["dense"]
         elif autoscale == 'SmoothQuant':
             nodes_list = ['dense', 'dense_4h_to_h']
-    elif isinstance(torch_model, GPTJForCausalLM) or isinstance(torch_model, GPTJForCausalLM_furiosa):
+    elif isinstance(torch_model, GPTJForCausalLM) or isinstance(torch_model, GPTJForCausalLM_furiosa) or isinstance(torch_model, GPTJForCausalLM_rope):
         if autoscale == 'AWQ':
             nodes_list = ["lm_head"]
         elif autoscale == 'SmoothQuant':
@@ -204,7 +205,7 @@ def _get_predefined_excluded_from_auto_clip_calib(torch_model):
         nodes_list = ['q_proj', 'k_proj', 'lm_head']
     elif isinstance(torch_model, BloomForCausalLM):
         nodes_list = ['query_key_value']
-    elif isinstance(torch_model, GPTJForCausalLM) or isinstance(torch_model, GPTJForCausalLM_furiosa):
+    elif isinstance(torch_model, GPTJForCausalLM) or isinstance(torch_model, GPTJForCausalLM_furiosa) or isinstance(torch_model, GPTJForCausalLM_rope):
         nodes_list = ['q_proj', 'k_proj', 'lm_head']
     elif "mpt" in str(torch_model.__class__).lower():
         nodes_list = []

--- a/language/gpt-j/quantization/autoscale/transform_descriptor_utils.py
+++ b/language/gpt-j/quantization/autoscale/transform_descriptor_utils.py
@@ -21,6 +21,7 @@ def _define_transform_descriptor_from_model_type(
     from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
     from transformers.models.bert.modeling_bert import BertForQuestionAnswering
     from furiosa_llm_models.gptj.huggingface import GPTJForCausalLM as GPTJForCausalLM_furiosa
+    from furiosa_llm_models.gptj.huggingface_rope import GPTJForCausalLM as GPTJForCausalLM_rope
 
     if_autoscale_postprocessor = not if_autoscale_preprocessor
     transform_descriptor = []
@@ -30,6 +31,7 @@ def _define_transform_descriptor_from_model_type(
         or isinstance(model, LlamaForCausalLM)
         or isinstance(model, GPTJForCausalLM)
         or isinstance(model, GPTJForCausalLM_furiosa)
+        or isinstance(model, GPTJForCausalLM_rope)
     ):
         if isinstance(model, OPTForCausalLM):
             _model_type = 'OPTForCausalLM'
@@ -37,6 +39,8 @@ def _define_transform_descriptor_from_model_type(
             _model_type = 'LlamaForCausalLM'
         elif isinstance(model, GPTJForCausalLM) or isinstance(model, GPTJForCausalLM_furiosa):
             _model_type = 'GPTJForCausalLM'
+        elif isinstance(model, GPTJForCausalLM) or isinstance(model, GPTJForCausalLM_rope):
+            _model_type = 'GPTJForCausalLM_rope'
 
         if if_autoscale_preprocessor:
             transform_descriptor.extend(
@@ -161,6 +165,7 @@ def load_predefined_settings(
     from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
     from transformers.models.bert.modeling_bert import BertForQuestionAnswering
     from furiosa_llm_models.gptj.huggingface import GPTJForCausalLM as GPTJForCausalLM_furiosa
+    from furiosa_llm_models.gptj.huggingface_rope import GPTJForCausalLM as GPTJForCausalLM_rope
     
     preprocessor = []
     postprocessor = []
@@ -171,6 +176,7 @@ def load_predefined_settings(
         or isinstance(model, GPTJForCausalLM)
         or isinstance(model, BertForQuestionAnswering)
         or isinstance(model, GPTJForCausalLM_furiosa)
+        or isinstance(model, GPTJForCausalLM_rope)
     ):
         preprocessor.extend(
             _define_transform_descriptor_from_model_type(


### PR DESCRIPTION
## 문제상황
- huggingface_rope import 수정
- autoscale/extract_kwargs.py, transform_descriptor_utils.py 에 rope 추가 

## 목적(해결방향)
- 

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

