### PR TITLE
Add GPTJdict 

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -48,7 +48,7 @@ class SUT_base():
             from furiosa_llm_models.gptj.paged_attention_concat import GPTJForCausalLM 
             model_cls = GPTJForCausalLM
         elif model_source == 'furiosa_llm_rope':
-            from furiosa_llm_models.models.gptj.huggingface_rope import GPTJForCausalLM
+            from furiosa_llm_models.gptj.huggingface_rope import GPTJForCausalLM
             model_cls = GPTJForCausalLM
         
         self.model = model_cls.from_pretrained(

--- a/language/gpt-j/quantization/autoscale/__init__.py
+++ b/language/gpt-j/quantization/autoscale/__init__.py
@@ -1,1 +1,2 @@
 from .extract_kwargs import *
+from .model_dict import *

--- a/language/gpt-j/quantization/autoscale/model_dict.py
+++ b/language/gpt-j/quantization/autoscale/model_dict.py
@@ -1,0 +1,12 @@
+import transformers
+import furiosa_llm_models
+
+
+#To DO: Add dictionaries for other models in furiosa-llm-models
+
+GPTJForCausalLM_dict = {
+    transformers.models.gptj.modeling_gptj.GPTJForCausalLM : transformers.models.gptj.modeling_gptj,
+    furiosa_llm_models.gptj.huggingface.GPTJForCausalLM : furiosa_llm_models.gptj.huggingface,
+    furiosa_llm_models.gptj.paged_attention_concat.GPTJForCausalLM : furiosa_llm_models.gptj.paged_attention_concat,
+    furiosa_llm_models.gptj.huggingface_rope.GPTJForCausalLM: furiosa_llm_models.gptj.huggingface_rope
+}

--- a/language/gpt-j/quantization/autoscale/transform_descriptor_utils.py
+++ b/language/gpt-j/quantization/autoscale/transform_descriptor_utils.py
@@ -167,6 +167,7 @@ def load_predefined_settings(
     if (
         isinstance(model, OPTForCausalLM)
         or isinstance(model, LlamaForCausalLM)
+        or isinstance(model, BertForQuestionAnswering)
         or type(model) in GPTJForCausalLM_dict.keys()
     ):
         preprocessor.extend(

--- a/language/gpt-j/quantization/autoscale/transform_descriptor_utils.py
+++ b/language/gpt-j/quantization/autoscale/transform_descriptor_utils.py
@@ -2,6 +2,9 @@ import json
 import logging
 
 import torch
+import transformers
+import furiosa_llm_models
+from .model_dict import GPTJForCausalLM_dict
 
 __all__ = ["create_descriptor_from_args", "load_predefined_settings"]
 
@@ -18,9 +21,8 @@ def _define_transform_descriptor_from_model_type(
     from transformers.models.bloom.modeling_bloom import BloomForCausalLM
     from transformers.models.llama.modeling_llama import LlamaForCausalLM
     from transformers.models.opt.modeling_opt import OPTForCausalLM
-    from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
     from transformers.models.bert.modeling_bert import BertForQuestionAnswering
-    from furiosa_llm_models.gptj.huggingface import GPTJForCausalLM as GPTJForCausalLM_furiosa
+
 
     if_autoscale_postprocessor = not if_autoscale_preprocessor
     transform_descriptor = []
@@ -28,14 +30,13 @@ def _define_transform_descriptor_from_model_type(
     if (
         isinstance(model, OPTForCausalLM)
         or isinstance(model, LlamaForCausalLM)
-        or isinstance(model, GPTJForCausalLM)
-        or isinstance(model, GPTJForCausalLM_furiosa)
+        or type(model) in GPTJForCausalLM_dict.keys()
     ):
         if isinstance(model, OPTForCausalLM):
             _model_type = 'OPTForCausalLM'
         elif isinstance(model, LlamaForCausalLM):
             _model_type = 'LlamaForCausalLM'
-        elif isinstance(model, GPTJForCausalLM) or isinstance(model, GPTJForCausalLM_furiosa):
+        elif type(model) in GPTJForCausalLM_dict.keys():
             _model_type = 'GPTJForCausalLM'
 
         if if_autoscale_preprocessor:
@@ -158,9 +159,7 @@ def load_predefined_settings(
     from transformers.models.bloom.modeling_bloom import BloomForCausalLM
     from transformers.models.llama.modeling_llama import LlamaForCausalLM
     from transformers.models.opt.modeling_opt import OPTForCausalLM
-    from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
     from transformers.models.bert.modeling_bert import BertForQuestionAnswering
-    from furiosa_llm_models.gptj.huggingface import GPTJForCausalLM as GPTJForCausalLM_furiosa
     
     preprocessor = []
     postprocessor = []
@@ -168,9 +167,7 @@ def load_predefined_settings(
     if (
         isinstance(model, OPTForCausalLM)
         or isinstance(model, LlamaForCausalLM)
-        or isinstance(model, GPTJForCausalLM)
-        or isinstance(model, BertForQuestionAnswering)
-        or isinstance(model, GPTJForCausalLM_furiosa)
+        or type(model) in GPTJForCausalLM_dict.keys()
     ):
         preprocessor.extend(
             _define_transform_descriptor_from_model_type(

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -66,8 +66,8 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
      #prepare for autoscale 
     if run_autoscale:
         autoscale_calib_cfg = get_autoscale_calib_config(model_script, model, calib_dataloader)
- 
-        
+
+
     model_type = type(model)
 
     if calib_dataloader:


### PR DESCRIPTION
## 문제상황
- FuriosaLLM을 사용함에 따라 transformer에 대한 hardcoding을 일반화 시켜야함
- FuriosaLLM-rope 추가 

## 목적(해결방향)
- 

## 구현 설명 Abstract
-GPTJForCausalLM_dict 추가
-


## 구현 설명 Detail (ex. 추가된 argument)

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

