### PR TITLE
fix bug

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -127,20 +127,14 @@ class SUT_base():
     def inference_call(self, input_ids_tensor, input_masks_tensor):
         ''' Common for all scenarios '''
         torch_device_type = 'cuda' if self.use_gpu else 'cpu'
-        input_batch = dict()
-        input_batch['input_ids'] = input_ids_tensor
-        input_batch['attention_mask'] = input_masks_tensor
-        # output_batch = self.model.generate(
-        #     **input_batch, **gen_kwargs, pad_token_id=self.tokenizer.eos_token_id)
-        output_batch = self.model.generate(input_batch, max_length = len(input_ids_tensor[0])*2)
+        
         with torch.inference_mode(), torch.autocast(device_type=torch_device_type, enabled=self.amp_enabled, dtype=self.amp_dtype if self.amp_enabled else None):
             input_batch = dict()
             input_batch['input_ids'] = input_ids_tensor
             input_batch['attention_mask'] = input_masks_tensor
-            # output_batch = self.model.generate(
-            #     **input_batch, **gen_kwargs, pad_token_id=self.tokenizer.eos_token_id)
-            output_batch = self.model.generate(input_batch, max_length = 7) 
-
+            output_batch = self.model.generate(
+                 **input_batch, **gen_kwargs, pad_token_id=self.tokenizer.eos_token_id)
+            
             input_batch_lengths = [x.shape[0]
                                    for x in input_batch["input_ids"]]
 


### PR DESCRIPTION
## 문제상황
- inference bug 수정

## 목적(해결방향)
- 

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

