### PR TITLE
Generate with preallocated_rope

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -59,20 +59,27 @@ class SUT_base():
         elif model_source == 'paged_attention_concat_rope':
             from furiosa_llm_models.gptj.paged_attention_concat_rope import GPTJForCausalLM
             model_cls = GPTJForCausalLM
-            self.gen_source  = 'QuantPagedAttentionGenerator'
+        elif model_source == 'preallocated_concat_rope':
+            from furiosa_llm_models.gptj.preallocated_concat_rope import GPTJForCausalLM
+            model_cls = GPTJForCausalLM 
         
-        if num_layers > 0:
-            from transformers import AutoConfig
-            config_exp =  AutoConfig.from_pretrained('EleutherAI/gpt-j-6B')
-            config_exp.n_layer = num_layers
-            self.model = model_cls.from_pretrained("EleutherAI/gpt-j-6B", config=config_exp)
-        else:
-            self.model = model_cls.from_pretrained(
-                self.model_path,
-                device_map="auto" if not self.use_gpu else None,
-                low_cpu_mem_usage=True if not self.use_gpu else False,
-                torch_dtype=self.amp_dtype
-            )
+        
+        self.model = model_cls.from_pretrained(
+            self.model_path,
+            device_map="auto" if not self.use_gpu else None,
+            low_cpu_mem_usage=True if not self.use_gpu else False,
+            torch_dtype=self.amp_dtype
+        )
+        
+        #control the # of layers for exp
+        # from transformers import AutoConfig
+        # config_exp =  AutoConfig.from_pretrained('EleutherAI/gpt-j-6B')
+        # config_exp.n_layer = 2
+        # self.model = model_cls.from_pretrained("EleutherAI/gpt-j-6B", config=config_exp)
+
+
+
+
 
         # Cast the model to GPU if the flag is set.
         if self.use_gpu:

--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -59,25 +59,24 @@ class SUT_base():
         elif model_source == 'paged_attention_concat_rope':
             from furiosa_llm_models.gptj.paged_attention_concat_rope import GPTJForCausalLM
             model_cls = GPTJForCausalLM
+            self.gen_source  = 'QuantPagedAttentionGenerator'
         elif model_source == 'preallocated_concat_rope':
             from furiosa_llm_models.gptj.preallocated_concat_rope import GPTJForCausalLM
             model_cls = GPTJForCausalLM 
+            self.gen_source = 'QuantPreAllocatedGenerator'
         
-        
-        self.model = model_cls.from_pretrained(
-            self.model_path,
-            device_map="auto" if not self.use_gpu else None,
-            low_cpu_mem_usage=True if not self.use_gpu else False,
-            torch_dtype=self.amp_dtype
-        )
-        
-        #control the # of layers for exp
-        # from transformers import AutoConfig
-        # config_exp =  AutoConfig.from_pretrained('EleutherAI/gpt-j-6B')
-        # config_exp.n_layer = 2
-        # self.model = model_cls.from_pretrained("EleutherAI/gpt-j-6B", config=config_exp)
-
-
+        if num_layers > 0:
+            from transformers import AutoConfig
+            config_exp =  AutoConfig.from_pretrained('EleutherAI/gpt-j-6B')
+            config_exp.n_layer = num_layers
+            self.model = model_cls.from_pretrained("EleutherAI/gpt-j-6B", config=config_exp)
+        else:
+            self.model = model_cls.from_pretrained(
+                self.model_path,
+                device_map="auto" if not self.use_gpu else None,
+                low_cpu_mem_usage=True if not self.use_gpu else False,
+                torch_dtype=self.amp_dtype
+            )
 
 
 

--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -145,6 +145,8 @@ class SUT_base():
                 output_batch = self.model.generate(**input_batch, **gen_kwargs, pad_token_id=self.tokenizer.eos_token_id)
             elif self.gen_source == 'QuantPagedAttentionGenerator':
                 output_batch = self.model.generate(input_batch, pad_token_id = self.tokenizer.pad_token_id, eos_token_id = self.model.model.prefill_model.config.eos_token_id)
+            elif self.gen_source == 'QuantPreAllocatedGenerator':
+                output_batch = self.model.generate(input_batch)
 
             input_batch_lengths = [x.shape[0]
                                    for x in input_batch["input_ids"]]

--- a/language/gpt-j/quantization/autoscale/model_dict.py
+++ b/language/gpt-j/quantization/autoscale/model_dict.py
@@ -9,5 +9,6 @@ GPTJForCausalLM_dict = {
     furiosa_llm_models.gptj.huggingface.GPTJForCausalLM : furiosa_llm_models.gptj.huggingface,
     furiosa_llm_models.gptj.paged_attention_concat.GPTJForCausalLM : furiosa_llm_models.gptj.paged_attention_concat,
     furiosa_llm_models.gptj.huggingface_rope.GPTJForCausalLM: furiosa_llm_models.gptj.huggingface_rope,
-    furiosa_llm_models.gptj.paged_attention_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.paged_attention_concat_rope
+    furiosa_llm_models.gptj.paged_attention_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.paged_attention_concat_rope,
+    furiosa_llm_models.gptj.preallocated_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.preallocated_concat_rope
 }

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -24,6 +24,7 @@ gen_kwargs = {
 GENERATOR_DICT = {
     furiosa_llm_models.gptj.paged_attention_concat.GPTJForCausalLM : furiosa_llm_models.generators.paged_attention_generator_concat.QuantPagedAttentionGenerator,
     furiosa_llm_models.gptj.paged_attention_concat_rope.GPTJForCausalLM : furiosa_llm_models.generators.paged_attention_generator_concat.QuantPagedAttentionGenerator,
+    furiosa_llm_models.gptj.preallocated_concat_rope.GPTJForCausalLM : furiosa_llm_models.generators.v2.PreAllocatedConcatGenerator,
 }
 
 def get_total_block_space(config, num_blocks = 32 , block_size = 1, bucket_size = 2048):


### PR DESCRIPTION
## 문제상황
- furiosa_llm_models.gptj.preallocated_concat_rope.GPTJForCausalLM에 대한 porting 및 Generate 기능이 필요함 

## 목적(해결방향)
- 해당 기능 구현 

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)


## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source preallocated_concat_rope"

## TODO (ex. 후속PR예고)
- 

