### PR TITLE
Support new pg attention

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -40,31 +40,35 @@ class SUT_base():
             self.amp_enabled = False
             self.amp_dtype = torch.float32
 
+
+
             
         if model_source == 'transformers':
             model_cls = AutoModelForCausalLM
             self.gen_source  = 'GenerationMixin'
-        elif model_source == 'furiosa_llm_original':
-            from furiosa_llm_models.gptj.huggingface import GPTJForCausalLM 
+        else:
+            if model_source == 'furiosa_llm_original':
+                from furiosa_llm_models.gptj.huggingface import GPTJForCausalLM 
+                self.gen_source  = 'GenerationMixin'
+            elif model_source == 'paged_attention_concat':
+                from furiosa_llm_models.gptj.paged_attention_concat import GPTJForCausalLM 
+                self.gen_source  = 'QuantPagedAttentionGenerator'
+            elif model_source == 'furiosa_llm_rope':
+                from furiosa_llm_models.gptj.huggingface_rope import GPTJForCausalLM
+                self.gen_source = 'GenerationMixin'
+            elif model_source == 'paged_attention_concat_rope':
+                from furiosa_llm_models.gptj.paged_attention_concat_rope import GPTJForCausalLM
+                self.gen_source  = 'QuantPagedAttentionGenerator'
+            elif model_source == 'preallocated_concat_rope':
+                from furiosa_llm_models.gptj.preallocated_concat_rope import GPTJForCausalLM
+                self.gen_source = 'QuantPreAllocatedGenerator'
+            elif model_source == 'paged_attention_rope':
+                from furiosa_llm_models.gptj.paged_attention_rope import GPTJForCausalLM
+                self.gen_source = 'QuantPagedAttentionGenerator'
+
             model_cls = GPTJForCausalLM
-            self.gen_source  = 'GenerationMixin'
-        elif model_source == 'paged_attention_concat':
-            from furiosa_llm_models.gptj.paged_attention_concat import GPTJForCausalLM 
-            model_cls = GPTJForCausalLM
-            self.gen_source  = 'QuantPagedAttentionGenerator'
-        elif model_source == 'furiosa_llm_rope':
-            from furiosa_llm_models.gptj.huggingface_rope import GPTJForCausalLM
-            model_cls = GPTJForCausalLM
-            self.gen_source = 'GenerationMixin'
-        elif model_source == 'paged_attention_concat_rope':
-            from furiosa_llm_models.gptj.paged_attention_concat_rope import GPTJForCausalLM
-            model_cls = GPTJForCausalLM
-            self.gen_source  = 'QuantPagedAttentionGenerator'
-        elif model_source == 'preallocated_concat_rope':
-            from furiosa_llm_models.gptj.preallocated_concat_rope import GPTJForCausalLM
-            model_cls = GPTJForCausalLM 
-            self.gen_source = 'QuantPreAllocatedGenerator'
-        
+
+
         if num_layers > 0:
             from transformers import AutoConfig
             config_exp =  AutoConfig.from_pretrained('EleutherAI/gpt-j-6B')
@@ -146,7 +150,7 @@ class SUT_base():
             elif self.gen_source == 'QuantPagedAttentionGenerator':
                 output_batch = self.model.generate(input_batch, pad_token_id = self.tokenizer.pad_token_id, eos_token_id = self.model.model.prefill_model.config.eos_token_id)
             elif self.gen_source == 'QuantPreAllocatedGenerator':
-                output_batch = self.model.generate(input_batch)
+                output_batch = self.model.generate(input_batch, **gen_kwargs)
 
             input_batch_lengths = [x.shape[0]
                                    for x in input_batch["input_ids"]]

--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -149,7 +149,7 @@ class SUT_base():
                 output_batch = self.model.generate(**input_batch, **gen_kwargs, pad_token_id=self.tokenizer.eos_token_id)
             elif self.gen_source == 'QuantPagedAttentionGenerator':
                 output_batch = self.model.generate(input_batch, pad_token_id = self.tokenizer.pad_token_id, eos_token_id = self.model.model.prefill_model.config.eos_token_id)
-            elif self.gen_source == 'QuantPreAllocatedGenerator':
+            elif self.gen_source == 'QuantPreAllocatedGenerator':  
                 output_batch = self.model.generate(input_batch, **gen_kwargs)
 
             input_batch_lengths = [x.shape[0]

--- a/language/gpt-j/quantization/autoscale/model_dict.py
+++ b/language/gpt-j/quantization/autoscale/model_dict.py
@@ -10,5 +10,6 @@ GPTJForCausalLM_dict = {
     furiosa_llm_models.gptj.paged_attention_concat.GPTJForCausalLM : furiosa_llm_models.gptj.paged_attention_concat,
     furiosa_llm_models.gptj.huggingface_rope.GPTJForCausalLM: furiosa_llm_models.gptj.huggingface_rope,
     furiosa_llm_models.gptj.paged_attention_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.paged_attention_concat_rope,
-    furiosa_llm_models.gptj.preallocated_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.preallocated_concat_rope
+    furiosa_llm_models.gptj.preallocated_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.preallocated_concat_rope,
+    furiosa_llm_models.gptj.paged_attention_rope.GPTJForCausalLM: furiosa_llm_models.gptj.paged_attention_rope,
 }

--- a/language/gpt-j/quantization/calibration_utils/__init__.py
+++ b/language/gpt-j/quantization/calibration_utils/__init__.py
@@ -1,0 +1,2 @@
+from. make_calib_dataloader import *
+from .paged_attention_utils import *

--- a/language/gpt-j/quantization/calibration_utils/make_calib_dataloader.py
+++ b/language/gpt-j/quantization/calibration_utils/make_calib_dataloader.py
@@ -1,0 +1,15 @@
+import torch
+from dataset import Dataset 
+from torch.utils.data import DataLoader
+
+__all__ = ["make_calib_dataloader"]
+
+
+def make_calib_dataloader(calib_dataset_path, batch_size):
+    data_object = Dataset(calib_dataset_path, batch_size)
+    data_list = []
+    for idx in range(len(data_object.source_encoded_input_ids)):
+        data_list.append({'input_ids': data_object.source_encoded_input_ids[idx], 'attention_mask': data_object.source_encoded_attn_masks[idx], 'position_ids': torch.arange(
+                len(data_object.source_encoded_input_ids[idx][0]))})
+    
+    return DataLoader(data_list, batch_size)

--- a/language/gpt-j/quantization/calibration_utils/paged_attention_utils.py
+++ b/language/gpt-j/quantization/calibration_utils/paged_attention_utils.py
@@ -1,0 +1,175 @@
+import torch
+from typing import List 
+from torch.utils.data import DataLoader
+from dataset import Dataset
+from furiosa_llm_models.gptj.paged_attention_utils import InputMetadata
+
+__all__ = ["make_calib_dataloader_for_paged_attention"]
+
+
+def update_input_metadata(updated_attention_mask: List[List[int]], block_indices, block_size, bucket_size):
+    new_key_locations = []
+    new_value_locations = []
+    batch_ids = []
+    # since it's both padding
+    # 일단 앞에서부터 하나씩 block 들을 만들고 block indices 를 부여하고 진짜인지 아닌지를 판단하기
+    # 앞에서부터 하나씩 끊어서 block 을 만들면 됨
+
+    available_block_indices = list(range(1, block_indices))
+    active_key_block_indices = ([])  
+    active_value_block_indices = ([]) 
+
+    for batch_idx, single_attention_mask in enumerate(updated_attention_mask):
+        batch_ids.append(torch.IntTensor([batch_idx]))
+        new_key_location = []
+        new_value_location = []
+        split_blocks = [
+            single_attention_mask[i : i + block_size]
+            for i in range(0, len(single_attention_mask), block_size)
+        ]
+
+        active_key_block_indices.append([])
+        active_value_block_indices.append([])
+
+        last_valid_key_block_idx = None
+        last_valid_value_block_idx = None
+        last_valid_token_idx = None
+
+        for block in split_blocks:
+            # x x 1 => then block is full
+            # 1 x x => block is not full
+            if sum(block) == 0:
+                # then this is zero block
+
+                new_key_location.append(torch.IntTensor([0]))
+                new_value_location.append(torch.IntTensor([0]))
+
+                active_key_block_indices[batch_idx].append(0)
+                active_value_block_indices[batch_idx].append(0)
+            else:
+                # find the idx of last 1
+                last_idx = 0
+                for idx, val in enumerate(block):
+                    if val == 1:
+                        last_idx = idx
+
+                new_key_block_idx = available_block_indices.pop()
+                new_value_block_idx = available_block_indices.pop()
+
+                new_key_location.append(torch.IntTensor([new_key_block_idx]))
+                new_value_location.append(torch.IntTensor([new_value_block_idx]))
+
+                active_key_block_indices[batch_idx].append(new_key_block_idx)
+                active_value_block_indices[batch_idx].append(new_value_block_idx)
+
+                last_valid_key_block_idx = new_key_block_idx
+                last_valid_value_block_idx = new_value_block_idx
+                last_valid_token_idx = last_idx
+
+        # self.valid_block_meta.append(
+        #     (
+        #         (last_valid_key_block_idx, last_valid_token_idx),
+        #         (last_valid_value_block_idx, last_valid_token_idx),
+        #     )
+        # )
+
+        new_key_locations.append(torch.unsqueeze(torch.cat(new_key_location), 0))
+        new_value_locations.append(torch.unsqueeze(torch.cat(new_value_location), 0))
+
+    new_key_locations = torch.cat(new_key_locations)
+    new_value_locations = torch.cat(new_value_locations)
+    batch_ids = torch.cat(batch_ids)
+
+    input_metadata = InputMetadata(
+        key_cache_idx=active_key_block_indices,
+        value_cache_idx=active_value_block_indices,
+        new_key_location=new_key_locations,
+        new_value_location=new_value_locations,
+        block_max_seq_len=int(bucket_size / block_size),
+        block_size=block_size, 
+        is_prefill=True,
+    )
+
+    input_metadata = [input_metadata.new_key_location.squeeze(0), input_metadata.new_value_location.squeeze(0), input_metadata.bucket_size, input_metadata.valid_key_indices.squeeze(0), input_metadata.valid_value_indices.squeeze(0)] 
+
+    return input_metadata
+
+def make_calib_dataloader_for_paged_attention(calib_dataset_path, batch_size, bucket_size, total_block_space):
+    # input_ids, attention_mask, bucket_size, total_block_space):
+    # The code is modified from furiosa-llm-models.generators.paged_attention_generator
+
+    #There could be a bug associated with multi-batch calibration in mcp at the moment. 
+    assert batch_size == 1 
+
+    data_object = Dataset(calib_dataset_path, batch_size)
+    data_list = []
+    block_indices, block_size, head, head_size = total_block_space[0][0].shape
+    for idx in range(len(data_object.source_encoded_input_ids)):
+        starting_input_ids = data_object.source_encoded_input_ids[idx]
+        final_input_ids = starting_input_ids
+        starting_attention_mask =  data_object.source_encoded_attn_masks[idx]
+        batch_size, starting_input_len = starting_input_ids.shape
+        bucketized_attention_mask = torch.zeros((batch_size, bucket_size), dtype=torch.int)
+        bucketized_attention_mask[:, :starting_input_len] = starting_attention_mask
+
+        #make position_ids
+        starting_position_id = []
+        for single_attention_mask in starting_attention_mask.tolist():
+            # find the first 1, then every before that is 1
+            # and new indexing from 0 begins there
+            # position ids is very similar to attention mask
+            # if bucket size = 8
+            # [[x x a b]
+            #  [a b c d]
+            #  [x x x a]]
+            # then, position id would be d
+            # [[1 1 0 1 2 3]
+            #  [0 1 2 3 4 5]
+            #  [1 1 1 0 1 2]]
+            target_idx = 0
+            for idx, value in enumerate(single_attention_mask):
+                if value == 1:
+                    target_idx = idx
+                    break
+
+            single_attention_mask[:target_idx] = [1] * target_idx
+            single_attention_mask[target_idx:] = list(
+                range(len(single_attention_mask) - target_idx)
+            )
+            single_position_id = torch.cat(
+                [
+                    torch.LongTensor(single_attention_mask).reshape(1, -1),
+                    torch.zeros((1, bucket_size - starting_input_len), dtype=torch.long),
+                ],
+                dim=1,
+            )
+            starting_position_id.append(single_position_id)
+
+        starting_position_ids = torch.cat(starting_position_id, dim=0)
+
+        bucketized_input_ids = torch.zeros((batch_size, bucket_size), dtype=torch.int)
+        bucketized_input_ids[:, :starting_input_len] = starting_input_ids
+
+        input_metadata = update_input_metadata(bucketized_attention_mask.tolist(), block_indices, block_size, bucket_size)
+
+        model_inputs= {"input_metadata": input_metadata,
+                        "input_ids": bucketized_input_ids.squeeze(0), 
+                        "attention_mask": bucketized_attention_mask.squeeze(0), 
+                        "position_ids": starting_position_ids.squeeze(0), 
+                        "past_key_values": total_block_space, 
+                    }
+        data_list.append(model_inputs)
+    
+
+    return DataLoader(data_list, batch_size)
+    
+
+
+
+
+        
+
+
+
+
+

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -238,4 +238,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             bucket_size, total_block_space = get_total_block_space(prefill_model.config)
             return generator(quant_causallm, total_block_space, bucket_size)
     else: 
+        if model_type == furiosa_llm_models.gptj.paged_attention_rope.GPTJForCausalLM:
+            raise NotImplementedError("QuantPagedAttentionGenerator for paged_attention_rope has not been implemented yet")
         return model_compressor.helper.QuantCausalLM(quant_models, model_type, input_names, concrete_args)

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -186,7 +186,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             dataloader=None,
             disable_inout=(True, True),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
-            decode_phase = True,
             model_name = "GPTJForCausalLM",
         )
         

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -24,7 +24,7 @@ GENERATOR_DICT = {
     furiosa_llm_models.gptj.paged_attention_concat.GPTJForCausalLM : furiosa_llm_models.generators.paged_attention_generator_concat.QuantPagedAttentionGenerator,
     furiosa_llm_models.gptj.paged_attention_concat_rope.GPTJForCausalLM : furiosa_llm_models.generators.paged_attention_generator_concat.QuantPagedAttentionGenerator,
     furiosa_llm_models.gptj.preallocated_concat_rope.GPTJForCausalLM : furiosa_llm_models.generators.v2.QuantPreAllocatedConcatGenerator,
-   # furiosa_llm_models.gptj.paged_attention_rope.GPTJForCausalLM: furiosa_llm_models.generators.paged_attention_generator.QuantPagedAttentionGenerator,
+   #furiosa_llm_models.gptj.paged_attention_rope.GPTJForCausalLM: furiosa_llm_models.generators.paged_attention_generator.QuantPagedAttentionGenerator,
 
 }
 
@@ -98,48 +98,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
 
 
     model_type = type(model)
-
-
-
-
-    #test code
-    # device = next(model.parameters()).device
-    # dummy_batch = next(iter(calib_dataloader))
-
-    # with torch.no_grad():
-    #     if isinstance(dummy_batch, dict):
-    #             for key in dummy_batch:
-    #                 if isinstance(dummy_batch[key], torch.Tensor):
-    #                     dummy_batch[key] = dummy_batch[key].to(device)
-    #                 elif isinstance(dummy_batch[key], list) and isinstance(dummy_batch[key][0], torch.Tensor):
-    #                     for idx in range(len(dummy_batch[key])):
-    #                             dummy_batch[key][idx] = dummy_batch[key][idx].squeeze(0).to(device)
-    #                 elif isinstance(dummy_batch[key], list) and isinstance(dummy_batch[key][0], list):
-    #                     for type_idx in range(len(dummy_batch[key])):
-    #                         for block_idx in range(len(dummy_batch[key][type_idx])): 
-    #                             dummy_batch[key][type_idx][block_idx] = dummy_batch[key][type_idx][block_idx].squeeze(0).to(device)
-
-    #             model(**dummy_batch)
-
-    # data_object = Dataset(calib_dataset_path, 1)
-    # data_list = []
-    # for idx in range(len(data_object.source_encoded_input_ids)):
-    #     data_list.append({'input_ids': data_object.source_encoded_input_ids[idx], 'attention_mask': data_object.source_encoded_attn_masks[idx], 'position_ids': torch.arange(
-    #             len(data_object.source_encoded_input_ids[idx][0]))})
-
-
-    # # def backend():
-    # #     from .dynamo import trace_utils
-    # #     return trace_utils.Mybackend()
-
-
-    # # 
-    # # bucket_size, total_block_space = get_total_block_space(prefill_model.config)
-    # # graph = torch.compile(model, backend = backend, fullgraph=True, dynamic = False)
-
-    # #test code 
-    # _, total_block_space = get_total_block_space(model.config)
-    # graph = torch.export.export(model, data_list[0])
 
     if calib_dataloader:
         if type(model) == furiosa_llm_models.gptj.paged_attention_rope.GPTJForCausalLM:


### PR DESCRIPTION
## 문제상황
- paged_attention_rope 지원 

## 목적(해결방향)
-  paged_attention_rope를 calibrate & trace 하는 기능

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- QuantPagedAttentionGenerator가 구현되지 않았기 떄문에, 해당 부분에 대해서 NotImplementedError raise 하도록 함 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
  -"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --calib-dataset-path ./data/cnn_dailymail_ci.json --gpu --accuracy --use_mcp --model_source paged_attention_rope --recalibrate"

## TODO (ex. 후속PR예고)
- QuantPagedAttentionGenerator

