### PR TITLE
add major data_type to qformat

### DIFF
--- a/language/bert/quantization/get_quant_model.py
+++ b/language/bert/quantization/get_quant_model.py
@@ -92,6 +92,8 @@ def get_quant_model(sut, model_script_path, n_calib, recalibrate):
             act_granularity=model_script["act_granularity"],
             act_dtype=model_script["act_dtype"],
             act_nbits=model_script["act_nbits"],
+            kv_dtype=model_script["kv_dtype"] if  "kv_dtype" in model_script else 'bf16',
+            disable_inout=(True, True),
         )
 
         quant_model.recompile()

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -151,7 +151,8 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
                 act_granularity=model_script["act_granularity"],
                 act_dtype=model_script["act_dtype"],
                 act_nbits=model_script["act_nbits"],
-                #disable_mods=args.disable_quant_list,
+                kv_dtype=model_script["kv_dtype"] if  "kv_dtype" in model_script else 'bf16',
+                disable_inout=(True, True),
             )
 
 


### PR DESCRIPTION
## 문제상황
- 플랫폼팀 요청으로 qformat 에 major dtype 정보가 필요

## 목적(해결방향)
- mcp 에 추가된 major dtype 추가해서 qformat save 하도록 변경

## 구현 설명 Abstract
- qformat save 시 kv_dtype, disable_inout 정보 추가


## 구현 설명 Detail (ex. 추가된 argument)
- qformat save 시 kv_dtype, disable_inout 정보 추가

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

