### PR TITLE
Port paged attention rope generator 

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -58,7 +58,7 @@ class SUT_base():
                 self.gen_source = 'GenerationMixin'
             elif model_source == 'paged_attention_concat_rope':
                 from furiosa_llm_models.gptj.paged_attention_concat_rope import GPTJForCausalLM
-                self.gen_source  = 'QuantPagedAttentionGenerator'
+                self.gen_source  = 'QuantPagedAttentionConcatGenerator'
             elif model_source == 'preallocated_concat_rope':
                 from furiosa_llm_models.gptj.preallocated_concat_rope import GPTJForCausalLM
                 self.gen_source = 'QuantPreAllocatedGenerator'
@@ -147,10 +147,15 @@ class SUT_base():
             # To Do: Implement beam seach for paged attention & preallocated generator
             if self.gen_source == 'GenerationMixin':
                 output_batch = self.model.generate(**input_batch, **gen_kwargs, pad_token_id=self.tokenizer.eos_token_id)
-            elif self.gen_source == 'QuantPagedAttentionGenerator':
+            elif self.gen_source == 'QuantPagedAttentionConcatGenerator':
                 output_batch = self.model.generate(input_batch, pad_token_id = self.tokenizer.pad_token_id, eos_token_id = self.model.model.prefill_model.config.eos_token_id)
             elif self.gen_source == 'QuantPreAllocatedGenerator':  
                 output_batch = self.model.generate(input_batch, **gen_kwargs)
+            elif self.gen_source == 'QuantPagedAttentionGenerator':
+                output_batch = self.model.generate(input_batch, **gen_kwargs)
+            else:
+                raise NotImplementedError
+
 
             input_batch_lengths = [x.shape[0]
                                    for x in input_batch["input_ids"]]

--- a/language/gpt-j/quantization/autoscale/model_dict.py
+++ b/language/gpt-j/quantization/autoscale/model_dict.py
@@ -7,7 +7,6 @@ import furiosa_llm_models
 GPTJForCausalLM_dict = {
     transformers.models.gptj.modeling_gptj.GPTJForCausalLM : transformers.models.gptj.modeling_gptj,
     furiosa_llm_models.gptj.huggingface.GPTJForCausalLM : furiosa_llm_models.gptj.huggingface,
-    furiosa_llm_models.gptj.paged_attention_concat.GPTJForCausalLM : furiosa_llm_models.gptj.paged_attention_concat,
     furiosa_llm_models.gptj.huggingface_rope.GPTJForCausalLM: furiosa_llm_models.gptj.huggingface_rope,
     furiosa_llm_models.gptj.paged_attention_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.paged_attention_concat_rope,
     furiosa_llm_models.gptj.preallocated_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.preallocated_concat_rope,

--- a/language/gpt-j/quantization/calibration_utils/paged_attention_utils.py
+++ b/language/gpt-j/quantization/calibration_utils/paged_attention_utils.py
@@ -31,9 +31,9 @@ def update_input_metadata(updated_attention_mask: List[List[int]], block_indices
         active_key_block_indices.append([])
         active_value_block_indices.append([])
 
-        last_valid_key_block_idx = None
-        last_valid_value_block_idx = None
-        last_valid_token_idx = None
+        # last_valid_key_block_idx = None
+        # last_valid_value_block_idx = None
+        # last_valid_token_idx = None
 
         for block in split_blocks:
             # x x 1 => then block is full
@@ -62,9 +62,9 @@ def update_input_metadata(updated_attention_mask: List[List[int]], block_indices
                 active_key_block_indices[batch_idx].append(new_key_block_idx)
                 active_value_block_indices[batch_idx].append(new_value_block_idx)
 
-                last_valid_key_block_idx = new_key_block_idx
-                last_valid_value_block_idx = new_value_block_idx
-                last_valid_token_idx = last_idx
+                # last_valid_key_block_idx = new_key_block_idx
+                # last_valid_value_block_idx = new_value_block_idx
+                # last_valid_token_idx = last_idx
 
         # self.valid_block_meta.append(
         #     (
@@ -100,7 +100,7 @@ def make_calib_dataloader_for_paged_attention(calib_dataset_path, batch_size, bu
 
     #There could be a bug associated with multi-batch calibration in mcp at the moment. 
     assert batch_size == 1 
-
+    # batch_size = 2
     data_object = Dataset(calib_dataset_path, batch_size)
     data_list = []
     block_indices, block_size, head, head_size = total_block_space[0][0].shape

--- a/language/gpt-j/quantization/calibration_utils/paged_attention_utils.py
+++ b/language/gpt-j/quantization/calibration_utils/paged_attention_utils.py
@@ -31,10 +31,6 @@ def update_input_metadata(updated_attention_mask: List[List[int]], block_indices
         active_key_block_indices.append([])
         active_value_block_indices.append([])
 
-        # last_valid_key_block_idx = None
-        # last_valid_value_block_idx = None
-        # last_valid_token_idx = None
-
         for block in split_blocks:
             # x x 1 => then block is full
             # 1 x x => block is not full
@@ -61,17 +57,6 @@ def update_input_metadata(updated_attention_mask: List[List[int]], block_indices
 
                 active_key_block_indices[batch_idx].append(new_key_block_idx)
                 active_value_block_indices[batch_idx].append(new_value_block_idx)
-
-                # last_valid_key_block_idx = new_key_block_idx
-                # last_valid_value_block_idx = new_value_block_idx
-                # last_valid_token_idx = last_idx
-
-        # self.valid_block_meta.append(
-        #     (
-        #         (last_valid_key_block_idx, last_valid_token_idx),
-        #         (last_valid_value_block_idx, last_valid_token_idx),
-        #     )
-        # )
 
         new_key_locations.append(torch.unsqueeze(torch.cat(new_key_location), 0))
         new_value_locations.append(torch.unsqueeze(torch.cat(new_value_location), 0))
@@ -100,7 +85,7 @@ def make_calib_dataloader_for_paged_attention(calib_dataset_path, batch_size, bu
 
     #There could be a bug associated with multi-batch calibration in mcp at the moment. 
     assert batch_size == 1 
-    # batch_size = 2
+
     data_object = Dataset(calib_dataset_path, batch_size)
     data_list = []
     block_indices, block_size, head, head_size = total_block_space[0][0].shape
@@ -162,7 +147,9 @@ def make_calib_dataloader_for_paged_attention(calib_dataset_path, batch_size, bu
     
 
     return DataLoader(data_list, batch_size)
-    
+
+
+
 
 
 


### PR DESCRIPTION
## 문제상황
- QuantPagedAttentionGenerator를 inference-compression에서 활용할 수 있도록 해야함

## 목적(해결방향)
- 

## 구현 설명 Abstract
- QuantPagedAttentionGenerator porting
- total_block_space dtype와 key, value dtype의 불일치를 방지하기 위하여 get_total_block_space 함수에 kv_dtype argument 추가 


## 구현 설명 Detail (ex. 추가된 argument)
- paged_attention_rope.GPTJForCausalLM은 항상 past_key_values를 input으로 받기 때문에, decode graph하나만 필요함.
- 따라서 quantcausallm을 활용하지 않음 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source paged_attention_rope"

## TODO (ex. 후속PR예고)
- 

