### PR TITLE
single two layer 모델 생성할 때 finetuned model 사용하도록 변경

### DIFF
--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -71,9 +71,9 @@ class SUT_base():
 
         if num_layers > 0:
             from transformers import AutoConfig
-            config_exp =  AutoConfig.from_pretrained('EleutherAI/gpt-j-6B')
+            config_exp =  AutoConfig.from_pretrained(self.model_path)
             config_exp.n_layer = num_layers
-            self.model = model_cls.from_pretrained("EleutherAI/gpt-j-6B", config=config_exp)
+            self.model = model_cls.from_pretrained(self.model_path, config=config_exp)
         else:
             self.model = model_cls.from_pretrained(
                 self.model_path,


### PR DESCRIPTION
## 문제상황
- single, two layer 모델 생성 시에 default gpt-j 로 만들어지도록 되어있음

## 목적(해결방향)
- mlperf fine tuned model 로 생성되도록 변경 필요

## 구현 설명 Abstract
- mlperf fine tuned model 로 생성되도록 변경


## 구현 설명 Detail (ex. 추가된 argument)
- mlperf fine tuned model 로 생성되도록 변경

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

