### PR TITLE
Apply llm models refactoring, Add paged_attention_optimized_packed

### DIFF
--- a/language/bert/pytorch_SUT.py
+++ b/language/bert/pytorch_SUT.py
@@ -141,7 +141,6 @@ class BERT_PyTorch_SUT():
                         )
                 
             if self.version >= '4.0.0':
-                import pdb;pdb.set_trace()
                 start_scores = model_output['start_logits']
                 end_scores = model_output['end_logits']
             else:

--- a/language/bert/run.py
+++ b/language/bert/run.py
@@ -58,6 +58,7 @@ def get_args():
     parser.add_argument("--n_calib", type=int,  default=-1)
     parser.add_argument('--torch_optim',default='default',type=str,choices=['default', 'none'],help='Torch optimization.',)
     parser.add_argument('--n_layers',default='-1',type=int, help='set the number of layers.',)
+    parser.add_argument('--model_source',default='unsplit_packed',type=str,choices=['huggingface', 'unsplit_packed'], help='choose model source',)
 
     args = parser.parse_args()
     return args
@@ -106,7 +107,7 @@ def main():
             raise ValueError("Unknown backend: {:}".format(args.backend))
     
     if args.use_mcp:
-        sut.model = get_quant_model(sut, args.model_script_path, args.n_calib, args.recalibrate)
+        sut.model = get_quant_model(sut, args.model_source, args.model_script_path, args.n_calib, args.recalibrate)
         
     settings = lg.TestSettings()
     settings.scenario = scenario_map[args.scenario]

--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -48,23 +48,20 @@ class SUT_base():
             self.gen_source  = 'GenerationMixin'
         else:
             if model_source == 'furiosa_llm_original':
-                from furiosa_llm_models.gptj.huggingface import GPTJForCausalLM 
+                from furiosa_llm_models.gptj.symbolic.huggingface import GPTJForCausalLM 
                 self.gen_source  = 'GenerationMixin'
-            elif model_source == 'paged_attention_concat':
-                from furiosa_llm_models.gptj.paged_attention_concat import GPTJForCausalLM 
-                self.gen_source  = 'QuantPagedAttentionGenerator'
             elif model_source == 'furiosa_llm_rope':
-                from furiosa_llm_models.gptj.huggingface_rope import GPTJForCausalLM
+                from furiosa_llm_models.gptj.symbolic.huggingface_rope import GPTJForCausalLM
                 self.gen_source = 'GenerationMixin'
-            elif model_source == 'paged_attention_concat_rope':
-                from furiosa_llm_models.gptj.paged_attention_concat_rope import GPTJForCausalLM
-                self.gen_source  = 'QuantPagedAttentionConcatGenerator'
-            elif model_source == 'preallocated_concat_rope':
-                from furiosa_llm_models.gptj.preallocated_concat_rope import GPTJForCausalLM
-                self.gen_source = 'QuantPreAllocatedGenerator'
             elif model_source == 'paged_attention_rope':
-                from furiosa_llm_models.gptj.paged_attention_rope import GPTJForCausalLM
-                self.gen_source = 'QuantPagedAttentionGenerator'
+                from furiosa_llm_models.gptj.symbolic.paged_attention_rope import GPTJForCausalLM
+                self.gen_source  = 'QuantPagedAttentionGenerator'
+            elif model_source == 'preallocated_concat_rope':
+                from furiosa_llm_models.gptj.symbolic.preallocated_concat_rope import GPTJForCausalLM
+                self.gen_source = 'QuantPreAllocatedGenerator'
+            elif model_source == 'paged_attention_optimized_packed':
+                from furiosa_llm_models.gptj.symbolic.paged_attention_optimized_packed_rope import GPTJForCausalLM
+                self.gen_source = 'PagedAttentionPackedGenerator'
 
             model_cls = GPTJForCausalLM
 
@@ -147,11 +144,11 @@ class SUT_base():
             # To Do: Implement beam seach for paged attention & preallocated generator
             if self.gen_source == 'GenerationMixin':
                 output_batch = self.model.generate(**input_batch, **gen_kwargs, pad_token_id=self.tokenizer.eos_token_id)
-            elif self.gen_source == 'QuantPagedAttentionConcatGenerator':
-                output_batch = self.model.generate(input_batch, pad_token_id = self.tokenizer.pad_token_id, eos_token_id = self.model.model.prefill_model.config.eos_token_id)
+            elif self.gen_source == 'QuantPagedAttentionGenerator':
+                output_batch = self.model.generate(input_batch, **gen_kwargs)
             elif self.gen_source == 'QuantPreAllocatedGenerator':  
                 output_batch = self.model.generate(input_batch, **gen_kwargs)
-            elif self.gen_source == 'QuantPagedAttentionGenerator':
+            elif self.gen_source == 'PagedAttentionPackedGenerator':
                 output_batch = self.model.generate(input_batch, **gen_kwargs)
             else:
                 raise NotImplementedError

--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -97,7 +97,9 @@ class SUT_base():
             padding_side="left",
             use_fast=False,)
         self.tokenizer.pad_token = self.tokenizer.eos_token
-
+        
+        self.model.config.pad_token_id = self.tokenizer.pad_token_id
+        
         self.data_object = Dataset(
             self.dataset_path, total_count_override=max_examples, num_splits=num_splits, split_idx=split_idx)
         self.qsl = lg.ConstructQSL(self.data_object.count, self.data_object.perf_count,

--- a/language/gpt-j/backend.py
+++ b/language/gpt-j/backend.py
@@ -149,7 +149,7 @@ class SUT_base():
             elif self.gen_source == 'QuantPreAllocatedGenerator':  
                 output_batch = self.model.generate(input_batch, **gen_kwargs)
             elif self.gen_source == 'PagedAttentionPackedGenerator':
-                output_batch = self.model.generate(input_batch, **gen_kwargs)
+                output_batch = self.model.generate(**input_batch, max_length=2048, **gen_kwargs)
             else:
                 raise NotImplementedError
 

--- a/language/gpt-j/quantization/autoscale/model_dict.py
+++ b/language/gpt-j/quantization/autoscale/model_dict.py
@@ -6,9 +6,9 @@ import furiosa_llm_models
 
 GPTJForCausalLM_dict = {
     transformers.models.gptj.modeling_gptj.GPTJForCausalLM : transformers.models.gptj.modeling_gptj,
-    furiosa_llm_models.gptj.huggingface.GPTJForCausalLM : furiosa_llm_models.gptj.huggingface,
-    furiosa_llm_models.gptj.huggingface_rope.GPTJForCausalLM: furiosa_llm_models.gptj.huggingface_rope,
-    furiosa_llm_models.gptj.paged_attention_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.paged_attention_concat_rope,
-    furiosa_llm_models.gptj.preallocated_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.preallocated_concat_rope,
-    furiosa_llm_models.gptj.paged_attention_rope.GPTJForCausalLM: furiosa_llm_models.gptj.paged_attention_rope,
+    furiosa_llm_models.gptj.symbolic.huggingface.GPTJForCausalLM : furiosa_llm_models.gptj.symbolic.huggingface,
+    furiosa_llm_models.gptj.symbolic.huggingface_rope.GPTJForCausalLM: furiosa_llm_models.gptj.symbolic.huggingface_rope,
+    furiosa_llm_models.gptj.symbolic.preallocated_concat_rope.GPTJForCausalLM: furiosa_llm_models.gptj.symbolic.preallocated_concat_rope,
+    furiosa_llm_models.gptj.symbolic.paged_attention_rope.GPTJForCausalLM: furiosa_llm_models.gptj.symbolic.paged_attention_rope,
+    furiosa_llm_models.gptj.symbolic.paged_attention_optimized_packed_rope.GPTJForCausalLM: furiosa_llm_models.gptj.symbolic.paged_attention_optimized_packed_rope,
 }

--- a/language/gpt-j/quantization/calibration_utils/__init__.py
+++ b/language/gpt-j/quantization/calibration_utils/__init__.py
@@ -1,2 +1,3 @@
 from. make_calib_dataloader import *
 from .paged_attention_utils import *
+from .paged_attention_optimized_packed_utils import * 

--- a/language/gpt-j/quantization/calibration_utils/paged_attention_optimized_packed_utils.py
+++ b/language/gpt-j/quantization/calibration_utils/paged_attention_optimized_packed_utils.py
@@ -1,0 +1,294 @@
+
+import os
+import random
+from typing import Dict, List, Tuple
+
+import torch
+from torch.utils.data import DataLoader
+from dataset import Dataset
+
+def prepare_prefill_input_metadata(
+        attention_mask: torch.Tensor, zero_block_index, available_block_indices, active_key_block_indices, active_value_block_indices
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        for prefill, valid_key_indices and valid_value_indices are none
+        return (new_key_location, new_value_location)
+        """
+        new_key_location = []  # shape = (batch, bucket_size)
+        new_value_location = []  # shape = (batch, bucket_size)
+        for single_attention_mask in attention_mask:
+            # for each attention_mask add zero block for padding
+            block_indices = []
+            for val in single_attention_mask:
+                if val == 0:
+                    # padding
+                    block_indices.append(zero_block_index)
+                else:
+                    block_indices.append(available_block_indices.pop())
+
+            active_key_block_indices.append(block_indices[:])
+            active_value_block_indices.append(block_indices)
+
+        new_key_location = torch.IntTensor(active_key_block_indices)
+        new_value_location = torch.IntTensor(active_value_block_indices)
+
+        return (
+            new_key_location,
+            new_value_location,
+        )
+
+
+def greedy_attention_packing(
+    input_ids: torch.Tensor,
+    bucketized_attention_mask: torch.Tensor,
+    new_key_location: torch.Tensor,
+    new_value_location: torch.Tensor,
+    eos_token_id: int,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    List[List[int]],
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """
+    return (packed_attention_mask, packed_input_ids, causal_mask, packed_position_ids, logit_target_locations, packed_new_key_location, packed_new_value_location)
+    """  # noqa: E501
+    assert input_ids.shape == bucketized_attention_mask.shape
+    assert bucketized_attention_mask.shape == new_key_location.shape
+    assert bucketized_attention_mask.shape == new_value_location.shape
+
+    logit_target_locations = []
+    (original_batch, bucket_size) = bucketized_attention_mask.shape
+
+    # split attention mask by batch
+    # print("bucketized attention mask: ", bucketized_attention_mask)
+    batch_real_len = []
+    for single_batch in bucketized_attention_mask:
+        num_real_token = single_batch.sum().item()
+        batch_real_len.append(num_real_token)
+
+    # find real tokens
+    # first convert all padding tensors to 0
+    converted_input_ids = torch.where(input_ids == eos_token_id, 0, input_ids)
+    non_zero_indices = converted_input_ids.nonzero().tolist()
+
+    # print("non zero indices: ", non_zero_indices)
+    # print("batch real len: ", batch_real_len)
+
+    real_locations = []
+    for i, real_len in enumerate(batch_real_len):
+        locations = [non_zero_indices.pop(0)[1] for _ in range(real_len)]
+        start = locations[0]
+        end = locations[-1] + 1
+        real_locations.append((i, start, end))
+
+    marker = bucket_size
+    target_locations: List[List[Tuple[int, int]]] = []  # List of List
+    temp_indices = []
+    for i in range(original_batch):
+        cur_len = batch_real_len[i]
+        if marker - cur_len < 0:
+            # we cannot pack so start a new row
+            target_locations.append(temp_indices)
+            temp_indices = []
+            marker = bucket_size
+
+        temp_indices.append((marker - cur_len, marker))
+        marker -= cur_len
+
+    # push the last row into the target locations
+    target_locations.append(temp_indices)
+
+    packed_batch_size = len(target_locations)
+
+    # initialize attention mask
+    packed_shape = (packed_batch_size, bucket_size)
+
+    packed_attention_mask = torch.zeros(packed_shape, dtype=torch.bool)
+    packed_input_ids = torch.zeros(packed_shape, dtype=torch.int32)
+    packed_new_key_location = torch.zeros(packed_shape, dtype=torch.int32)
+    packed_new_value_location = torch.zeros(packed_shape, dtype=torch.int32)
+    position_ids = torch.ones(packed_shape, dtype=torch.long)
+
+    # initialize causal mask
+    causal_mask = torch.zeros((packed_batch_size, bucket_size, bucket_size), dtype=torch.bool)
+
+    # fill the new attention mask and mark the logit locations
+    for index, target_location in enumerate(target_locations):
+        # record new target locations
+        logit_target_location = []
+        for start, end in target_location:
+            (original_index, original_start, original_end) = real_locations.pop(0)
+            packed_attention_mask[index][start:end] = True
+            packed_input_ids[index][start:end] = input_ids[original_index][
+                original_start:original_end
+            ]
+            packed_new_key_location[index][start:end] = new_key_location[original_index][
+                original_start:original_end
+            ]
+            packed_new_value_location[index][start:end] = new_value_location[original_index][
+                original_start:original_end
+            ]
+            position_ids[index][start:end] = torch.arange(end - start)
+            logit_target_location.append(end - 1)
+            # print(
+            #     "index: {index}, start: {start}, end: {end}".format(
+            #         index=index, start=start, end=end
+            #     )
+            # )
+            causal_mask[index][start:end, start:end] = torch.tril(
+                torch.ones((end - start, end - start), dtype=torch.bool)
+            )
+        logit_target_locations.append(logit_target_location)
+
+    return (
+        packed_attention_mask,
+        packed_input_ids,
+        causal_mask,
+        logit_target_locations,
+        position_ids,
+        packed_new_key_location,
+        packed_new_value_location,
+    )
+
+def prepare_prefill_inputs(
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    new_key_location: torch.Tensor,
+    new_value_location: torch.Tensor,
+    eos_token_id: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[List[int]]]:
+    """
+    return (packed_input_ids, causal_mask, packed_position_ids, logit_target_locations, packed_new_key_locatoin, packed_new_value_location)
+    """  # noqa: E501
+    (
+        packed_attention_mask,
+        packed_input_ids,
+        causal_mask,
+        logit_target_locations,
+        packed_position_ids,
+        packed_new_key_location,
+        packed_new_value_location,
+    ) = greedy_attention_packing(
+        input_ids,
+        attention_mask,
+        new_key_location,
+        new_value_location,
+        eos_token_id=eos_token_id,
+    )
+    return (
+        packed_input_ids,
+        packed_attention_mask,
+        causal_mask,
+        packed_position_ids,
+        logit_target_locations,
+        packed_new_key_location,
+        packed_new_value_location,
+    )
+
+def prepare_decode_input_metadata(active_key_block_indices, active_value_block_indices, available_block_indices
+)-> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        return (new_key_location, new_value_location, valid_key_indices, valid_valie_indices)
+        """
+        new_key_location = []  # shape = (batch, 1)
+        new_value_location = []  # shape = (batch, 1)
+        valid_key_indices = []  # shape = (batch*(bucket_size -1))
+        valid_value_indices = []  #
+        for key_batch, value_batch in zip(
+            active_key_block_indices, active_value_block_indices
+        ):
+            valid_key_indices.extend(key_batch[:-1])
+            valid_value_indices.extend(value_batch[:-1])
+
+            # we use same block idx for key and value here
+            new_block_idx = available_block_indices.pop()
+
+            key_batch[-1] = new_block_idx
+            value_batch[-1] = new_block_idx
+
+            new_key_location.append([new_block_idx])
+            new_value_location.append([new_block_idx])
+
+        new_key_location = torch.IntTensor(new_key_location)
+        new_value_location = torch.IntTensor(new_value_location)
+        valid_key_indices = torch.IntTensor(valid_key_indices)
+        valid_value_indices = torch.IntTensor(valid_value_indices)
+
+        return (
+            new_key_location,
+            new_value_location,
+            valid_key_indices,
+            valid_value_indices,
+        )
+
+def make_calib_dataloader_for_paged_attention_packed(
+    calib_dataset_path, config, batch_size, bucket_size, total_block_space
+):
+    # input_ids, attention_mask, bucket_size, total_block_space):
+    # The code is modified from furiosa-llm-models.generators.paged_attention_generator
+
+    # There could be a bug associated with multi-batch calibration in mcp at the moment.
+    assert batch_size == 1 
+
+    data_object = Dataset(calib_dataset_path, batch_size)
+    data_list = []
+    block_indices, block_size, head, head_size = total_block_space[0][0].shape
+    eos_token_id = config.eos_token_id
+    for idx in range(len(data_object.source_encoded_input_ids)):
+        # ----------- initial_settings -----------------
+        active_key_block_indices = []
+        active_value_block_indices = []
+        available_block_indices = list(range(1, block_indices))
+        zero_block_index = 0  # this is a special zero block
+
+        starting_input_ids = data_object.source_encoded_input_ids[idx]
+        starting_attention_mask = data_object.source_encoded_attn_masks[idx]
+        batch_size, prompt_len = starting_input_ids.shape
+        
+        starting_position_ids = starting_attention_mask.long().cumsum(-1) - 1
+        starting_position_ids.masked_fill_(starting_attention_mask == 0, 1)
+
+        # ----------- adjust to bucket settings --------
+        attention_mask = torch.zeros((batch_size, bucket_size), dtype=torch.int)
+        attention_mask[:, :prompt_len] = starting_attention_mask
+
+        input_ids = torch.zeros((batch_size, bucket_size), dtype=torch.int)
+        input_ids[:, :prompt_len] = starting_input_ids
+
+        position_ids = torch.zeros((batch_size, bucket_size), dtype=torch.long)
+        position_ids[:, :prompt_len] = starting_position_ids
+
+        (new_key_location, new_value_location) = prepare_prefill_input_metadata(attention_mask, zero_block_index, available_block_indices, active_key_block_indices, active_value_block_indices)
+
+        (
+                packed_input_ids,
+                _packed_attention_mask,  # this attention mask if for debugging purpose
+                causal_mask,
+                packed_position_ids,
+                logit_target_locations,
+                new_key_location,
+                new_value_location,
+        ) = prepare_prefill_inputs(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                new_key_location=new_key_location,
+                new_value_location=new_value_location,
+                eos_token_id=eos_token_id,
+        )  
+
+        model_inputs = {
+        "input_ids": packed_input_ids,
+        "causal_mask": causal_mask,
+        "position_ids": packed_position_ids,
+        "past_key_values": total_block_space,
+        "new_key_location": new_key_location,
+        "new_value_location": new_value_location,
+        }
+
+        data_list.append(model_inputs)
+
+    return DataLoader(data_list)

--- a/language/gpt-j/quantization/calibration_utils/paged_attention_optimized_packed_utils.py
+++ b/language/gpt-j/quantization/calibration_utils/paged_attention_optimized_packed_utils.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Tuple
 import torch
 from torch.utils.data import DataLoader
 from dataset import Dataset
+from furiosa_llm_models.generators.packing import greedy_attention_packing
 
 def prepare_prefill_input_metadata(
         attention_mask: torch.Tensor, zero_block_index, available_block_indices, active_key_block_indices, active_value_block_indices
@@ -38,128 +39,12 @@ def prepare_prefill_input_metadata(
         )
 
 
-def greedy_attention_packing(
-    input_ids: torch.Tensor,
-    bucketized_attention_mask: torch.Tensor,
-    new_key_location: torch.Tensor,
-    new_value_location: torch.Tensor,
-    eos_token_id: int,
-) -> Tuple[
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    List[List[int]],
-    torch.Tensor,
-    torch.Tensor,
-]:
-    """
-    return (packed_attention_mask, packed_input_ids, causal_mask, packed_position_ids, logit_target_locations, packed_new_key_location, packed_new_value_location)
-    """  # noqa: E501
-    assert input_ids.shape == bucketized_attention_mask.shape
-    assert bucketized_attention_mask.shape == new_key_location.shape
-    assert bucketized_attention_mask.shape == new_value_location.shape
-
-    logit_target_locations = []
-    (original_batch, bucket_size) = bucketized_attention_mask.shape
-
-    # split attention mask by batch
-    # print("bucketized attention mask: ", bucketized_attention_mask)
-    batch_real_len = []
-    for single_batch in bucketized_attention_mask:
-        num_real_token = single_batch.sum().item()
-        batch_real_len.append(num_real_token)
-
-    # find real tokens
-    # first convert all padding tensors to 0
-    converted_input_ids = torch.where(input_ids == eos_token_id, 0, input_ids)
-    non_zero_indices = converted_input_ids.nonzero().tolist()
-
-    # print("non zero indices: ", non_zero_indices)
-    # print("batch real len: ", batch_real_len)
-
-    real_locations = []
-    for i, real_len in enumerate(batch_real_len):
-        locations = [non_zero_indices.pop(0)[1] for _ in range(real_len)]
-        start = locations[0]
-        end = locations[-1] + 1
-        real_locations.append((i, start, end))
-
-    marker = bucket_size
-    target_locations: List[List[Tuple[int, int]]] = []  # List of List
-    temp_indices = []
-    for i in range(original_batch):
-        cur_len = batch_real_len[i]
-        if marker - cur_len < 0:
-            # we cannot pack so start a new row
-            target_locations.append(temp_indices)
-            temp_indices = []
-            marker = bucket_size
-
-        temp_indices.append((marker - cur_len, marker))
-        marker -= cur_len
-
-    # push the last row into the target locations
-    target_locations.append(temp_indices)
-
-    packed_batch_size = len(target_locations)
-
-    # initialize attention mask
-    packed_shape = (packed_batch_size, bucket_size)
-
-    packed_attention_mask = torch.zeros(packed_shape, dtype=torch.bool)
-    packed_input_ids = torch.zeros(packed_shape, dtype=torch.int32)
-    packed_new_key_location = torch.zeros(packed_shape, dtype=torch.int32)
-    packed_new_value_location = torch.zeros(packed_shape, dtype=torch.int32)
-    position_ids = torch.ones(packed_shape, dtype=torch.long)
-
-    # initialize causal mask
-    causal_mask = torch.zeros((packed_batch_size, bucket_size, bucket_size), dtype=torch.bool)
-
-    # fill the new attention mask and mark the logit locations
-    for index, target_location in enumerate(target_locations):
-        # record new target locations
-        logit_target_location = []
-        for start, end in target_location:
-            (original_index, original_start, original_end) = real_locations.pop(0)
-            packed_attention_mask[index][start:end] = True
-            packed_input_ids[index][start:end] = input_ids[original_index][
-                original_start:original_end
-            ]
-            packed_new_key_location[index][start:end] = new_key_location[original_index][
-                original_start:original_end
-            ]
-            packed_new_value_location[index][start:end] = new_value_location[original_index][
-                original_start:original_end
-            ]
-            position_ids[index][start:end] = torch.arange(end - start)
-            logit_target_location.append(end - 1)
-            # print(
-            #     "index: {index}, start: {start}, end: {end}".format(
-            #         index=index, start=start, end=end
-            #     )
-            # )
-            causal_mask[index][start:end, start:end] = torch.tril(
-                torch.ones((end - start, end - start), dtype=torch.bool)
-            )
-        logit_target_locations.append(logit_target_location)
-
-    return (
-        packed_attention_mask,
-        packed_input_ids,
-        causal_mask,
-        logit_target_locations,
-        position_ids,
-        packed_new_key_location,
-        packed_new_value_location,
-    )
-
 def prepare_prefill_inputs(
     input_ids: torch.Tensor,
     attention_mask: torch.Tensor,
     new_key_location: torch.Tensor,
     new_value_location: torch.Tensor,
-    eos_token_id: int,
+    pad_token_id: int,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[List[int]]]:
     """
     return (packed_input_ids, causal_mask, packed_position_ids, logit_target_locations, packed_new_key_locatoin, packed_new_value_location)
@@ -177,7 +62,7 @@ def prepare_prefill_inputs(
         attention_mask,
         new_key_location,
         new_value_location,
-        eos_token_id=eos_token_id,
+        pad_token_id=pad_token_id,
     )
     return (
         packed_input_ids,
@@ -188,42 +73,6 @@ def prepare_prefill_inputs(
         packed_new_key_location,
         packed_new_value_location,
     )
-
-def prepare_decode_input_metadata(active_key_block_indices, active_value_block_indices, available_block_indices
-)-> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """
-        return (new_key_location, new_value_location, valid_key_indices, valid_valie_indices)
-        """
-        new_key_location = []  # shape = (batch, 1)
-        new_value_location = []  # shape = (batch, 1)
-        valid_key_indices = []  # shape = (batch*(bucket_size -1))
-        valid_value_indices = []  #
-        for key_batch, value_batch in zip(
-            active_key_block_indices, active_value_block_indices
-        ):
-            valid_key_indices.extend(key_batch[:-1])
-            valid_value_indices.extend(value_batch[:-1])
-
-            # we use same block idx for key and value here
-            new_block_idx = available_block_indices.pop()
-
-            key_batch[-1] = new_block_idx
-            value_batch[-1] = new_block_idx
-
-            new_key_location.append([new_block_idx])
-            new_value_location.append([new_block_idx])
-
-        new_key_location = torch.IntTensor(new_key_location)
-        new_value_location = torch.IntTensor(new_value_location)
-        valid_key_indices = torch.IntTensor(valid_key_indices)
-        valid_value_indices = torch.IntTensor(valid_value_indices)
-
-        return (
-            new_key_location,
-            new_value_location,
-            valid_key_indices,
-            valid_value_indices,
-        )
 
 def make_calib_dataloader_for_paged_attention_packed(
     calib_dataset_path, config, batch_size, bucket_size, total_block_space
@@ -237,7 +86,8 @@ def make_calib_dataloader_for_paged_attention_packed(
     data_object = Dataset(calib_dataset_path, batch_size)
     data_list = []
     block_indices, block_size, head, head_size = total_block_space[0][0].shape
-    eos_token_id = config.eos_token_id
+
+    pad_token_id = config.pad_token_id
     for idx in range(len(data_object.source_encoded_input_ids)):
         # ----------- initial_settings -----------------
         active_key_block_indices = []
@@ -277,7 +127,7 @@ def make_calib_dataloader_for_paged_attention_packed(
                 attention_mask=attention_mask,
                 new_key_location=new_key_location,
                 new_value_location=new_value_location,
-                eos_token_id=eos_token_id,
+                pad_token_id=pad_token_id,
         )  
 
         model_inputs = {

--- a/language/gpt-j/quantization/calibration_utils/paged_attention_utils.py
+++ b/language/gpt-j/quantization/calibration_utils/paged_attention_utils.py
@@ -2,7 +2,7 @@ import torch
 from typing import List 
 from torch.utils.data import DataLoader
 from dataset import Dataset
-from furiosa_llm_models.gptj.paged_attention_utils import InputMetadata
+from furiosa_llm_models.gptj.symbolic.paged_attention_utils import InputMetadata
 
 __all__ = ["make_calib_dataloader_for_paged_attention"]
 

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -38,7 +38,7 @@ def get_total_block_space(config, batch_size = 1, block_size = 1, bucket_size = 
     else:
         raise NotImplementedError
     
-    num_blocks = bucket_size * batch_size + 1
+    num_blocks = batch_size * 4  * 2 * (bucket_size) * block_size + 1
     example_block_per_layer_shape = (
         num_blocks,
         block_size,

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -77,7 +77,7 @@ def get_autoscale_calib_config(model_script, model, calib_dataloader):
 
 
 
-def get_quant_model(model, calib_dataset_path, model_script_path,weighted_op_emul_dtype, recalibrate):
+def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
     # Load model script and calibration dataloader (Refer to inference-compression/language/gpt-j/README.md on how to download evaluation and calibration dataset )
     model_script = load_model_script(model_script_path)
 
@@ -196,7 +196,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path,weighted_op_emu
             dataloader=None,
             disable_inout=(True, True),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
-            weighted_op_emul_dtype=weighted_op_emul_dtype,
+            delete_org_weight=True,
             model_name = "GPTJForCausalLM",
         )
         generator = FURIOSA_GENERATOR_DICT[model_type]
@@ -238,6 +238,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path,weighted_op_emu
             disable_inout=(True, True),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
             decode_phase = False,
+            delete_org_weight=True,
             model_name = "GPTJForCausalLM",
         )
 
@@ -260,6 +261,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path,weighted_op_emu
             disable_inout=(True, True),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
             decode_phase = True,
+            delete_org_weight=True,
             model_name = "GPTJForCausalLM",
             quantized_prefill_model=prefill_model,
         )

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -26,7 +26,7 @@ FURIOSA_GENERATOR_DICT = {
     furiosa_llm_models.gptj.symbolic.paged_attention_optimized_packed_rope.GPTJForCausalLM: furiosa_llm_models.generators.paged_attention_optimized_generator_beam_search.PagedAttentionGeneratorBeamSearch,
 }
 
-def get_total_block_space(config, batch_size = 1, num_blocks = 32 , block_size = 1, bucket_size = 2048, kv_dtype = 'float32'):
+def get_total_block_space(config, batch_size = 1, block_size = 1, bucket_size = 2048, kv_dtype = 'float32'):
     #artibrary set to accomodate input prompt & generated summary
     
     if kv_dtype == 'float32':


### PR DESCRIPTION
## 문제상황
- llm models refactoring 변경 사항 반영 필요
- paged_attention_optimized_packed_rope 모델 추가
- mcp 변경 사항 반영 

## 목적(해결방향)
- llm models refactoring으로 symbolic 폴더의 모델들 사용
- paged_attention_optimized_packed_rope calibration dataloader 생성 및 backend 수정 필요
- paged_attention_concat_rope 은 제거함 

## 구현 설명 Abstract
- llm models refactoring으로 symbolic 폴더의 모델들 사용, v3.5 결과와 동치확인 (hf_rope, preallocated, paged_attention_rope)
- 민혁님이 작성하신 MCP paged_attention_optimized_packed_rope test 코드 참고해서 구현 
- original model fp32 weight release 하도록 args 입력


## 구현 설명 Detail (ex. 추가된 argument)
- 현재 paged_attention_optimized_packed_rope 는 calibration 불가, prefill input 생성하는 부분에 수정이 필요함 [slack](https://furiosa-ai.slack.com/archives/C06R68UU9DJ/p1716288047364119)
- random input calib (민혁님 test 코드 사용) 한 qformat, qparam 으로 generate 단계에서 Runtime Error 발생함, 원인 파악 중, furiosa-llm-models 부분이므로 PR 생성함


## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

