### PR TITLE
remove model name for gptj in inference

### DIFF
--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -197,14 +197,13 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             disable_inout=(True, True),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
             delete_org_weight=True,
-            model_name = "GPTJForCausalLM",
         )
         generator = FURIOSA_GENERATOR_DICT[model_type]
 
         # only a single graph is  required for paged_attention_rope 
         bucket_size, total_block_space = get_total_block_space(decode_model.config, kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16')
         return generator(decode_model, model_type, total_block_space, bucket_size) 
-
+    
     else: 
         prefill_model, prefill_input_names, prefill_concrete_args = model_compressor.helper.gptj_custom_symbolic_trace(model, prefill_mode = True, disable_check = True)
         decode_model, decode_input_names, decode_concrete_args = model_compressor.helper.gptj_custom_symbolic_trace(model, prefill_mode = False, disable_check = True)
@@ -239,7 +238,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
             decode_phase = False,
             delete_org_weight=True,
-            model_name = "GPTJForCausalLM",
         )
 
         decode_model = model_compressor.create_quantsim_model(
@@ -262,7 +260,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
             decode_phase = True,
             delete_org_weight=True,
-            model_name = "GPTJForCausalLM",
             quantized_prefill_model=prefill_model,
         )
 


### PR DESCRIPTION
## 문제상황
- model_name을 explicit하게 넣어주는게 불편함 
- 해당 불편함을 해소하기 위하여 MCP의 함수로부터 model_name argument가 사라짐

## 목적(해결방향)
- RunTimeError 방지를 위하여 inference-compression에서도 해당 argument 제거 

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- huggingface_rope에서 main과 accuracy ci 동치 나오는 것 확인 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [x] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source huggingface_rope"

## TODO (ex. 후속PR예고)
- 

