### PR TITLE
remove calib argument

### DIFF
--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -139,7 +139,6 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
 
         model_compressor.calibrate(
             model=model_for_calib,
-            model_name=model_script["model"],
             calib_dataloader=calib_dataloader,
             weight_calib_method=model_script["weight_calib_method"],
             weight_granularity=model_script["weight_granularity"],


### PR DESCRIPTION
## 문제상황
- calibration 함수에 model_name argument입력이 남아있음

## 목적(해결방향)
- 해당 argument 제거 

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

