### PR TITLE
Calibration with padded inputs

### DIFF
--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -44,9 +44,10 @@ def get_args():
     parser.add_argument("--recalibrate", action="store_true", default=False, help="load already existing quantization metadata")
     parser.add_argument("--num_splits", type=int, default=1, help="")
     parser.add_argument("--split_idx", type=int, default=0, help="")
-    parser.add_argument('--torch_optim',default='default',type=str,choices=['default', 'none'],help='Torch optimization.',)
+    parser.add_argument('--torch_optim',default='none',type=str,choices=['default', 'none'],help='Torch optimization.',)
     parser.add_argument("--model_source", type = str, default = "furiosa_llm_original", help="the type of GPTJForCausalLM to use")
     parser.add_argument('--n_layers',default='-1',type=int, help='set the number of layers.',)
+    parser.add_argument('--calib_without_padding', action="store_true", default=False, help="use mcp to quantize the model")
     
     args = parser.parse_args()
     return args
@@ -78,7 +79,7 @@ def main():
     )
 
     if args.use_mcp:
-        sut.model = quantization.get_quant_model(sut.model, args.calib_dataset_path, args.model_script_path, args.recalibrate)
+        sut.model = quantization.get_quant_model(sut.model, args.calib_dataset_path, args.model_script_path, args.calib_without_padding, args.recalibrate)
 
     settings = lg.TestSettings()
     settings.scenario = scenario_map[args.scenario]

--- a/language/gpt-j/quantization/calibration_utils/make_calib_dataloader.py
+++ b/language/gpt-j/quantization/calibration_utils/make_calib_dataloader.py
@@ -5,11 +5,30 @@ from torch.utils.data import DataLoader
 __all__ = ["make_calib_dataloader"]
 
 
-def make_calib_dataloader(calib_dataset_path, batch_size):
+def make_calib_dataloader(calib_dataset_path, batch_size, calib_without_padding):
     data_object = Dataset(calib_dataset_path, batch_size)
     data_list = []
     for idx in range(len(data_object.source_encoded_input_ids)):
-        data_list.append({'input_ids': data_object.source_encoded_input_ids[idx], 'attention_mask': data_object.source_encoded_attn_masks[idx], 'position_ids': torch.arange(
-                len(data_object.source_encoded_input_ids[idx][0]))})
+        if calib_without_padding:
+            data_list.append({'input_ids': data_object.source_encoded_input_ids[idx], 'attention_mask': data_object.source_encoded_attn_masks[idx], 'position_ids': torch.arange(
+                    len(data_object.source_encoded_input_ids[idx][0]))})
+            
+        else:
+            bucket_size=2048
+            starting_input_ids = data_object.source_encoded_input_ids[idx]
+            batch_size, starting_input_len = starting_input_ids.shape
+            bucketized_input_ids = torch.zeros((batch_size, bucket_size), dtype=torch.int)
+            bucketized_input_ids[:, :starting_input_len] = starting_input_ids
+            
+            starting_attention_mask =  data_object.source_encoded_attn_masks[idx]
+            bucketized_attention_mask = torch.zeros((batch_size, bucket_size), dtype=torch.int)
+            bucketized_attention_mask[:, :starting_input_len] = starting_attention_mask
+            
+            starting_position_ids = torch.arange(len(data_object.source_encoded_input_ids[idx][0])).reshape(1,-1)
+            bucketized_position_ids = torch.cat([starting_position_ids, torch.zeros((1, bucket_size - starting_input_len), dtype=torch.long)], dim=1)
+            
+            data_list.append({'input_ids': bucketized_input_ids,
+                            'attention_mask': bucketized_attention_mask,
+                            'position_ids': bucketized_position_ids.squeeze(0)})
     
     return DataLoader(data_list, batch_size)

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -77,7 +77,7 @@ def get_autoscale_calib_config(model_script, model, calib_dataloader):
 
 
 
-def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
+def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_padding, recalibrate):
     # Load model script and calibration dataloader (Refer to inference-compression/language/gpt-j/README.md on how to download evaluation and calibration dataset )
     model_script = load_model_script(model_script_path)
 
@@ -99,7 +99,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, recalibrate):
         
         else:
             from .calibration_utils.make_calib_dataloader import make_calib_dataloader
-            calib_dataloader = make_calib_dataloader(calib_dataset_path, model_script['calib_batch_size'])
+            calib_dataloader = make_calib_dataloader(calib_dataset_path, model_script['calib_batch_size'], calib_without_padding)
             
   
     run_autoscale = model_script.get("autoscale", 'disabled') != 'disabled'  


### PR DESCRIPTION
## 문제상황
- padded input 으로 calibration 하는 옵션 추가

## 목적(해결방향)
- padded input 으로 calibration 하는 옵션 추가

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

