### PR TITLE
BERT furiosa-llm-models helper 로 tracing and model_source 변경 huggingface_rngd_gelu, mlperf_submission

### DIFF
--- a/language/bert/pytorch_SUT.py
+++ b/language/bert/pytorch_SUT.py
@@ -59,10 +59,10 @@ class BERT_PyTorch_SUT():
         
         print("Loading PyTorch model...")
         
-        if self.model_source == 'huggingface':
-            from furiosa_llm_models.bert.symbolic.huggingface import BertForQuestionAnswering
-        elif self.model_source == 'unsplit_packed':
-            from furiosa_llm_models.bert.symbolic.huggingface_unsplit_packed import BertForQuestionAnswering
+        if self.model_source == 'huggingface_rngd_gelu':
+            from furiosa_llm_models.bert.symbolic.huggingface_rngd_gelu import BertForQuestionAnswering
+        elif self.model_source == 'mlperf_submission':
+            from furiosa_llm_models.bert.symbolic.mlperf_submission import BertForQuestionAnswering
         
         self.model = BertForQuestionAnswering(config)
         self.model.to(self.dev)
@@ -93,12 +93,12 @@ class BERT_PyTorch_SUT():
             segment_ids = sample_input.segment_ids
 
         with torch.no_grad():
-            if self.model_source == 'huggingface':
+            if self.model_source == 'huggingface_rngd_gelu':
                 model_output = self.model.forward(input_ids=torch.LongTensor(input_ids).unsqueeze(0).to(self.dev),
                     attention_mask=torch.LongTensor(input_mask).unsqueeze(0).to(self.dev),
                     token_type_ids=torch.LongTensor(segment_ids).unsqueeze(0).to(self.dev))
-            elif self.model_source == 'unsplit_packed':
-                """
+            elif self.model_source == 'mlperf_submission':
+                
                 from furiosa_llm_models.generators.packing import greedy_attention_packing_bert
                 from torch.nn.functional import pad
 
@@ -128,8 +128,8 @@ class BERT_PyTorch_SUT():
                     attention_mask=attention_mask,
                     position_ids=position_ids
                     )
+                
                 """
-
                 padded_sequences={}
                 padded_sequences['input_ids'] = torch.LongTensor(sample_input.input_ids).unsqueeze(0).to(self.dev)
                 padded_sequences['attention_mask'] = torch.LongTensor(sample_input.input_mask).unsqueeze(0).to(self.dev)
@@ -139,7 +139,7 @@ class BERT_PyTorch_SUT():
                         bucket_size=512,
                         pad_token_id=0,
                         )
-                
+                """
             if self.version >= '4.0.0':
                 start_scores = model_output['start_logits']
                 end_scores = model_output['end_logits']

--- a/language/bert/quantization/calib_dataloader/calib_dataloader.py
+++ b/language/bert/quantization/calib_dataloader/calib_dataloader.py
@@ -21,6 +21,7 @@ def make_packed_calib_data_loader(calib_dataset, bucket_size, pad_token_id):
                 token_type_ids=bucket_pad(batch["token_type_ids"]),
                 bucketized_attention_mask=bucket_pad(batch["attention_mask"]),
                 pad_token_id=pad_token_id,
+                compact_mask=False,
             )
         )
 

--- a/language/bert/run.py
+++ b/language/bert/run.py
@@ -56,9 +56,9 @@ def get_args():
     parser.add_argument("--use_mcp", action="store_true", help="use mcp to quantize the model")
     parser.add_argument("--recalibrate", action="store_true", default=False, help="load already existing quantization metadata")
     parser.add_argument("--n_calib", type=int,  default=-1)
-    parser.add_argument('--torch_optim',default='default',type=str,choices=['default', 'none'],help='Torch optimization.',)
+    parser.add_argument('--torch_optim',default='none',type=str,choices=['default', 'none'],help='Torch optimization.',)
     parser.add_argument('--n_layers',default='-1',type=int, help='set the number of layers.',)
-    parser.add_argument('--model_source',default='unsplit_packed',type=str,choices=['huggingface', 'unsplit_packed'], help='choose model source',)
+    parser.add_argument('--model_source',default='unsplit_packed',type=str,choices=['huggingface_rngd_gelu', 'mlperf_submission'], help='choose model source',)
 
     args = parser.parse_args()
     return args


### PR DESCRIPTION
## 문제상황
- BERT furiosa-llm-models helper 로 tracing 
- model_source 변경 huggingface_rngd_gelu, mlperf_submission(huggingface_unsplit_packed, compact mask x)


## 목적(해결방향)
- BERT furiosa-llm-models helper 로 tracing 
- huggingface_rngd_gelu, mlperf_submission 지원

## 구현 설명 Abstract
- BERT furiosa-llm-models helper 로 tracing 
- huggingface_rngd_gelu, mlperf_submission 지원


## 구현 설명 Detail (ex. 추가된 argument)
- 기존 huggingface 와 huggingface_rngd_gelu 모델 100 sample 에서 score 동일함을 확인 (recalibrate 하고 evaluation 수행)
    - 100 samples: {"exact_match": 93.0, "f1": 94.86666666666667}
    - full test: {"exact_match": 83.99243140964995, "f1": 91.04695978810247}
    
- compact maks version 추가될 때 greedy_attention_packing_bert( ) 에 compact_mask=True 로 변경되어야함 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)


