### PR TITLE
Fix typo

### DIFF
--- a/language/llama2-70b/main_ci.py
+++ b/language/llama2-70b/main_ci.py
@@ -9,7 +9,7 @@ from torch.nn.functional import pad
 import model_compressor
 from quantization.utils import get_kwargs, random_seed, set_optimization
 from quantization.get_quant_model import get_quant_model
-from quantization.calibrate import cal_data_loader, calibrate
+from quantization.calibrate import make_calib_dataloader, calibrate
 
 
 # Assume BLOCK_SIZE, NUM_BLOCKS, BUCKET_SIZE are fixed for now.
@@ -197,7 +197,7 @@ def test_model_equivalence():
         if 'qlevel' in qconfig:
             qconfig['qlevel'] = 2
             
-        dataloader = cal_data_loader(model, args.model_source, args.calib_data_path, qconfig["calib_batch_size"], args.n_calib)
+        dataloader = make_calib_dataloader(model, args.model_source, args.calib_data_path, qconfig["calib_batch_size"], args.n_calib)
         calibrate(
             model,
             args.model_source,

--- a/language/llama2-70b/quantization/calibrate.py
+++ b/language/llama2-70b/quantization/calibrate.py
@@ -193,6 +193,9 @@ def main():
                 "Inference on a device other than GPU is not suppurted yet."
             )
         model = load_pytorch_model(args.model_source, args.model_path, args.gpu, args.n_layers)
+        if hasattr(model, 'hf_device_map'):
+            model.device_map = model.hf_device_map
+            model.module_name =  model.__class__.__module__ + "." + model.__class__.__name__
 
     else:
         raise ValueError("Unsupported backend: {:}".format(args.backend))

--- a/language/llama2-70b/quantization/calibrate.py
+++ b/language/llama2-70b/quantization/calibrate.py
@@ -55,7 +55,7 @@ def load_pytorch_model(model_source, model_path, use_gpu, n_layers):
     return model
 
 
-def cal_data_loader(model, model_source, data_path, batch_size, n_calib, max_seq_len=1024, use_generator_dataloader_with_unpacked_model=False):
+def make_calib_dataloader(model, model_source, data_path, batch_size, n_calib, max_seq_len=1024, use_generator_dataloader_with_unpacked_model=False):
     if not os.path.isfile(data_path):
         print("Calibration dataset {} not found. Please check that the path is correct".format(data_path))
     
@@ -94,7 +94,7 @@ def cal_data_loader(model, model_source, data_path, batch_size, n_calib, max_seq
 
 def calibrate(model, model_source, qconfig, qparam_path, qformat_path, calib_dataloader):
     if model_source == 'mlperf_submission':
-        model = model.trace_decode()
+        model = model.trace_prefill()
     else:
         model, _,_ = model_compressor.helper.llama_custom_symbolic_trace(
             model,
@@ -202,7 +202,7 @@ def main():
 
     with open(args.quant_config_path, "r") as f:
         qconfig = yaml.safe_load(f)
-    dataloader = cal_data_loader(
+    dataloader = make_calib_dataloader(
         model, args.model_source, args.calib_data_path, qconfig["calib_batch_size"], args.n_calib, use_generator_dataloader_with_unpacked_model=args.use_generator_dataloader_with_unpacked_model
     )
     calibrate(


### PR DESCRIPTION
## 문제상황
- function이름 수정 필요
- calibrate에서 decode graph를 호출하고 있음

## 목적(해결방향)
- function이름 수정
- calibrate에서 prefill graph를 호출하도록 수정

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

