### PR TITLE
Move bert generator init

### DIFF
--- a/language/bert/pytorch_SUT.py
+++ b/language/bert/pytorch_SUT.py
@@ -142,9 +142,7 @@ class BERT_PyTorch_SUT:
                 padded_sequences["attention_mask"] = attention_mask
                 padded_sequences["token_type_ids"] = token_type_ids
 
-                from furiosa_llm_models.generators.bert_generator import (
-                    BertUnsplitPackedGenerator,
-                )
+
 
                 if self.debug_mode:
                     # 첫번째 샘플에 대해서 비교 진행
@@ -156,10 +154,7 @@ class BERT_PyTorch_SUT:
                         }
                     )
 
-                generator = BertUnsplitPackedGenerator(
-                    model=self.model, compact_mask=False
-                )
-                model_output = generator.generate(
+                model_output = self.model.generate(
                     **padded_sequences,
                     bucket_size=384,
                     pad_token_id=0,

--- a/language/bert/quantization/get_quant_model.py
+++ b/language/bert/quantization/get_quant_model.py
@@ -132,7 +132,14 @@ def get_quant_model(sut, model_source, model_script_path, n_calib, recalibrate, 
         disable_inout=(True,True),
     )
     
+    if model_source == 'mlperf_submission':
+        from furiosa_llm_models.generators.bert_generator import BertUnsplitPackedGenerator
+        generator = BertUnsplitPackedGenerator(model=quant_model, compact_mask=False)
+    else:
+        generator = None
     
+    if generator is None:
+        return quant_model
     
-    return quant_model
+    return generator
     

--- a/language/bert/run_ci.py
+++ b/language/bert/run_ci.py
@@ -195,9 +195,14 @@ def dump_using_mlperf_loadgens(args, sut, dumpfile_path):
     # Enable debug mode
     # ---------------------------------------------------------
     sut.debug_mode = True
+    if args.model_source == "mlperf_submission":
+        quant_model = sut.model.model
+    else:
+        quant_model = ut.model
+
     model_compressor.set_model_to_dump_golden_model(
         dumpfile_path,
-        sut.model,
+        quant_model,
         dumping_range="qlv4_linear",
         dumping_mode="only-in-out",
         qlv4_skip_output_rounding=False,

--- a/language/bert/run_ci.py
+++ b/language/bert/run_ci.py
@@ -198,7 +198,7 @@ def dump_using_mlperf_loadgens(args, sut, dumpfile_path):
     if args.model_source == "mlperf_submission":
         quant_model = sut.model.model
     else:
-        quant_model = ut.model
+        quant_model = sut.model
 
     model_compressor.set_model_to_dump_golden_model(
         dumpfile_path,


### PR DESCRIPTION
## 문제상황
- Bert generator가 매 generate 함수 call전에 반복되어 생성되고 있음.

## 목적(해결방향)
- quant_model이 생성되는 get_quant_model() 함수 내로 generator 생성 부분 이동

## 구현 설명 Abstract
- generator를 정의하는 모델인 경우, get_quant_model에서 generator를 return하고, sut.model에 입력됨. (gpt-j 방식과 일치시켰습니다.)
- 해당 변경에 따른 run_ci.py 업데이트

## 구현 설명 Detail (ex. 추가된 argument)
-

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [X] GPU pod
    -  python run_ci.py @lanauge/bert 통과 확인
- [ ] warboy pod

## TODO (ex. 후속PR예고)
- 

