### PR TITLE
apply changed get_quant_model to main.py

### DIFF
--- a/language/gpt-j/main.py
+++ b/language/gpt-j/main.py
@@ -48,6 +48,8 @@ def get_args():
     parser.add_argument("--model_source", type = str, default = "furiosa_llm_original", help="the type of GPTJForCausalLM to use")
     parser.add_argument('--n_layers',default='-1',type=int, help='set the number of layers.',)
     parser.add_argument('--calib_without_padding', action="store_true", default=False, help="use mcp to quantize the model")
+    parser.add_argument('--qformat_path', type = str, default=None, help="")
+    parser.add_argument('--qparam_path', type = str, default=None, help="")
     
     args = parser.parse_args()
     return args
@@ -79,7 +81,7 @@ def main():
     )
 
     if args.use_mcp:
-        sut.model = quantization.get_quant_model(sut.model, args.calib_dataset_path, args.model_script_path, args.calib_without_padding, args.recalibrate)
+        sut.model = quantization.get_quant_model(sut.model, args.calib_dataset_path, args.model_script_path, args.calib_without_padding, args.recalibrate, args.qformat_path, args.qparam_path)
 
     settings = lg.TestSettings()
     settings.scenario = scenario_map[args.scenario]

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -84,6 +84,11 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
     # Load model script and calibration dataloader (Refer to inference-compression/language/gpt-j/README.md on how to download evaluation and calibration dataset )
     model_script = load_model_script(model_script_path)
     
+    if qformat_path is None and qparam_path is None:
+        qformat_path = f"./quantization/output/qformat_{model_script_path.split('.')[1].split('/')[-1]}.yaml" 
+        qparam_path = f"./quantization/output/qparam_{model_script_path.split('.')[1].split('/')[-1]}.npy"
+    
+    
     if os.path.exists(qformat_path) and os.path.exists(qparam_path) and recalibrate == False:
         calib_dataloader = None
     else:


### PR DESCRIPTION
**##** 문제상황
- get_quant_model() 이 qformat, qparam 을 입력 받도록 변경된 사항 미반영 되어있음

## 목적(해결방향)
- get_quant_model() 이 qformat, qparam 을 입력 받도록 변경함

## 구현 설명 Abstract
- get_quant_model() 이 qformat, qparam 을 입력 받도록 변경함, args 입력하지 않으면 이전과 동일하게 script 이름 기반으로 자동 생성됨


## 구현 설명 Detail (ex. 추가된 argument)
- get_quant_model() 이 qformat, qparam 을 입력 받도록 변경함, args 입력하지 않으면 이전과 동일하게 script 이름 기반으로 자동 생성됨

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

