### PR TITLE
split evaluation

### DIFF
--- a/language/llama2-70b/SUT.py
+++ b/language/llama2-70b/SUT.py
@@ -98,7 +98,10 @@ class SUT():
                  dataset_path=None,
                  use_cached_outputs=False,  # Set this to True *only for test accuracy runs* in case your prior session was killed partway through
                  n_layers=-1,
-                 workers=1):
+                 workers=1,
+                 num_splits=1,
+                 split_idx=0,
+                 ):
 
         self.model_path = model_path or "meta-llama/Llama-2-70b-chat-hf"
         self.model_source = model_source
@@ -129,7 +132,9 @@ class SUT():
         self.data_object = Dataset(self.model_path,
                                    dataset_path=self.dataset_path,
                                    total_sample_count=total_sample_count,
-                                   device=self.device)
+                                   device=self.device,
+                                   num_splits=num_splits,
+                                   split_idx=split_idx)
         self.qsl = lg.ConstructQSL(self.data_object.total_sample_count, self.data_object.perf_count,
                                    self.data_object.LoadSamplesToRam, self.data_object.UnloadSamplesFromRam)
 

--- a/language/llama2-70b/main.py
+++ b/language/llama2-70b/main.py
@@ -27,7 +27,6 @@ def get_args():
     parser.add_argument("--output-log-dir", type=str, default="output-logs", help="Where logs are saved")
     parser.add_argument("--enable-log-trace", action="store_true", help="Enable log tracing. This file can become quite large")
     parser.add_argument("--num-workers", type=int, default=1, help="Number of workers to process queries")
-    
     parser.add_argument("--model_source", 
                         choices=[
                             "furiosa_llm_rope", 
@@ -43,7 +42,8 @@ def get_args():
     parser.add_argument('--torch_numeric_optim', action="store_true", help="use Pytorch numerical optimizaiton for CUDA/cudnn")
     parser.add_argument("--n_layers", type=int, default=-1, help="Set the number of layers of the model.")
     parser.add_argument("--weighted_op_emul_dtype", type=str, default="fp32", help="set emulation type of weighted operators")
-
+    parser.add_argument("--num_splits", type=int, default=1, help="")
+    parser.add_argument("--split_idx", type=int, default=0, help="")
 
     args = parser.parse_args()
     return args
@@ -95,6 +95,8 @@ def main():
         total_sample_count=args.total_sample_count,
         device=args.device,
         n_layers=args.n_layers,
+        num_splits=args.num_splits,
+        split_idx=args.split_idx,
     )
     
     if args.quantize:


### PR DESCRIPTION
## 문제상황
- data 를 나눠돌리는 기능 필요

## 목적(해결방향)
- data 를 나눠돌리는 기능 추가

## 구현 설명 Abstract
-data 를 나눠돌리는 기능 추가


## 구현 설명 Detail (ex. 추가된 argument)
- 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

