### PR TITLE
update mlperf.conf v4.1

### DIFF
--- a/mlperf.conf
+++ b/mlperf.conf
@@ -19,13 +19,13 @@ stable-diffusion-xl.*.performance_sample_count_override = 5000
 3d-unet.*.performance_sample_count_override = 0
 
 # Set seeds. The seeds will be distributed two weeks before the submission.
-*.*.qsl_rng_seed = 13281865557512327830
-*.*.sample_index_rng_seed = 198141574272810017
-*.*.schedule_rng_seed = 7575108116881280410
+*.*.qsl_rng_seed = 3066443479025735752
+*.*.sample_index_rng_seed = 10688027786191513374
+*.*.schedule_rng_seed = 14962580496156340209
 # Set seeds for TEST_05. The seeds will be distributed two weeks before the submission.
-*.*.test05_qsl_rng_seed = 2376919268182438552
-*.*.test05_sample_index_rng_seed = 11176391829184272374
-*.*.test05_schedule_rng_seed = 3911940905271271337
+*.*.test05_qsl_rng_seed = 16799458546791641818
+*.*.test05_sample_index_rng_seed = 5453809927556429288
+*.*.test05_schedule_rng_seed = 5435552105434836064
 
 
 *.SingleStream.target_latency_percentile = 90
@@ -41,9 +41,9 @@ retinanet.MultiStream.target_latency = 528
 3d-unet.*.sample_concatenate_permutation = 1
 
 # LLM benchmarks have non-uniform inputs and outputs, and use equal issue mode for all latency scenario
-gptj.Server.sample_concatenate_permutation = 1
-gptj.SingleStream.sample_concatenate_permutation = 1
-llama2-70b.Server.sample_concatenate_permutation = 1
+gptj.*.sample_concatenate_permutation = 1
+llama2-70b.*.sample_concatenate_permutation = 1
+mixtral-8x7B.*.sample_concatenate_permutation = 1
 
 *.Server.target_latency = 10
 *.Server.target_latency_percentile = 99
@@ -57,12 +57,20 @@ dlrm-v2.Server.target_latency = 60
 rnnt.Server.target_latency = 1000
 gptj.Server.target_latency = 20000
 stable-diffusion-xl.Server.target_latency = 20000
-# Falcon Server scenario requires two latency constraints
+# Llama2-70b benchmarks measures token latencies
 llama2-70b.*.use_token_latencies = 1
-# Only ttft and tpot are tracked for the llama2-70b benchmark therefore target_latency = 0
+mixtral-8x7b.*.use_token_latencies = 1
+# gptj benchmark infers token latencies
+gptj.*.infer_token_latencies = 1
+gptj.*.token_latency_scaling_factor = 69
+# Only ttft and tpot are tracked for the llama2-70b & mixtral-8x7B benchmark therefore target_latency = 0
 llama2-70b.Server.target_latency = 0
 llama2-70b.Server.ttft_latency = 2000
 llama2-70b.Server.tpot_latency = 200
+
+mixtral-8x7b.Server.target_latency = 0
+mixtral-8x7b.Server.ttft_latency = 2000
+mixtral-8x7b.Server.tpot_latency = 200
 
 *.Offline.target_latency_percentile = 90
 *.Offline.min_duration = 600000
@@ -81,6 +89,7 @@ rnnt.Offline.min_query_count = 2513
 3d-unet.Offline.min_query_count = 43
 stable-diffusion-xl.Offline.min_query_count = 5000
 llama2-70b.Offline.min_query_count = 24576
+mixtral-8x7b.Offline.min_query_count = 15000
 
 # These fields should be defined and overridden by user.conf.
 *.SingleStream.target_latency = 10


### PR DESCRIPTION
## 문제상황
- v4.1 기준 mlperf.conf 로 update 필요

## 목적(해결방향)
- v4.1 기준 mlperf.conf 로 update 

## 구현 설명 Abstract
- v4.1 기준 mlperf.conf 로 update  


## 구현 설명 Detail (ex. 추가된 argument)
- 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

