### PR TITLE
Fix pg dataloader

### DIFF
--- a/language/gpt-j/quantization/calibration_utils/dataset_paged_attention.py
+++ b/language/gpt-j/quantization/calibration_utils/dataset_paged_attention.py
@@ -35,7 +35,7 @@ class Dataset_for_paged_attention(Dataset):
                 self.total_block_space[type_idx][block_idx] = self.total_block_space[type_idx][block_idx].to(kv_cache_device)
                             
                 
-    def empty_total_block_space(self, device, device_map = None):
+    def init_total_block_space(self, device, device_map = None):
         tensor_shape = self.total_block_space[0][0].shape
         dtype = self.total_block_space[0][0].dtype
         for type_idx in range(len(self.total_block_space)):

--- a/language/gpt-j/quantization/calibration_utils/dataset_paged_attention.py
+++ b/language/gpt-j/quantization/calibration_utils/dataset_paged_attention.py
@@ -35,5 +35,14 @@ class Dataset_for_paged_attention(Dataset):
                 self.total_block_space[type_idx][block_idx] = self.total_block_space[type_idx][block_idx].to(kv_cache_device)
                             
                 
-        
+    def empty_total_block_space(self, device, device_map = None):
+        tensor_shape = self.total_block_space[0][0].shape
+        dtype = self.total_block_space[0][0].dtype
+        for type_idx in range(len(self.total_block_space)):
+            for block_idx in range(len(self.total_block_space[type_idx])):
+                kv_cache_device = device
+                if device_map is not None and len(device_map) > 0:
+                    if isinstance(device[str(type_idx)], int):
+                        kv_cache_device = device[str(type_idx)]
+                self.total_block_space[type_idx][block_idx] = torch.zeros(tensor_shape, dtype = dtype).to(kv_cache_device)
         

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -29,7 +29,7 @@ FURIOSA_GENERATOR_DICT = {
     
 }
 
-def get_total_block_space(config, batch_size = 1, block_size = 1, bucket_size = 2048, kv_dtype = 'float32'):
+def get_total_block_space(config, batch_size = 1, block_size = 1, bucket_size = 2048, num_beams = 4, kv_dtype = 'float32', max_prompt_len = None):
     #artibrary set to accomodate input prompt & generated summary
     
     if kv_dtype == 'float32':
@@ -41,7 +41,11 @@ def get_total_block_space(config, batch_size = 1, block_size = 1, bucket_size = 
     else:
         raise NotImplementedError
     
-    num_blocks = batch_size * 2 * (1920) * block_size + 1
+    if max_prompt_len:
+        num_blocks = batch_size * num_beams * 2 * (max_prompt_len) * block_size + 1 
+    else:
+        num_blocks = batch_size  * num_beams * 2 * (bucket_size) * block_size + 1 
+
     example_block_per_layer_shape = (
         num_blocks,
         block_size,
@@ -98,7 +102,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
             calib_dataloader =  make_calib_dataloader_for_paged_attention(calib_dataset_path, model_script['calib_batch_size'], bucket_size, total_block_space)
         elif type(model) in [furiosa_llm_models.gptj.symbolic.mlperf_submission.GPTJForCausalLM,]:
             from .calibration_utils.paged_attention_optimized_packed_utils import make_calib_dataloader_for_paged_attention_packed
-            bucket_size, total_block_space = get_total_block_space(model.config, kv_dtype = 'float32') #kv_dtype are set as float32 to enable dummy forwarding before calibration.
+            bucket_size, total_block_space = get_total_block_space(model.config, kv_dtype = 'float32', num_beams = 1, max_prompt_len = 1920) #kv_dtype are set as float32 to enable dummy forwarding before calibration.
             calib_dataloader =  make_calib_dataloader_for_paged_attention_packed(calib_dataset_path, model.config, model_script['calib_batch_size'], bucket_size, total_block_space)
         # elif type(model) == furiosa_llm_models.gptj.paged_attentin_rope
         

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -278,8 +278,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
 
         if model_type in FURIOSA_GENERATOR_DICT.keys():
             generator = FURIOSA_GENERATOR_DICT[model_type]
-            if generator == furiosa_llm_models.generators.symbolic.quant_preallocated_concat_generator.QuantPreAllocatedConcatGenerator:
-                return generator(quant_causallm, bucket_size = 2048)
+            if generator == furiosa_llm_models.generators.paged_attention_optimized_generator_beam_search_optimized.PagedAttentionGeneratorBeamSearch:
                 quant_models["prefill_model"].concrete_args = concrete_args["prefill_concrete_args"]
                 quant_models["decode_model"].concrete_args = concrete_args["decode_concrete_args"]
                 return generator(prefill=quant_models["prefill_model"], decode=quant_models["decode_model"], kv_dtype=torch.int8)

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -41,7 +41,7 @@ def get_total_block_space(config, batch_size = 1, block_size = 1, bucket_size = 
     else:
         raise NotImplementedError
     
-    num_blocks = batch_size * 2 * (bucket_size) * block_size + 1
+    num_blocks = batch_size * 2 * (1920) * block_size + 1
     example_block_per_layer_shape = (
         num_blocks,
         block_size,

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -21,7 +21,7 @@ gen_kwargs = {
 
 
 FURIOSA_GENERATOR_DICT = {
-    furiosa_llm_models.gptj.symbolic.mlperf_submission.GPTJForCausalLM : furiosa_llm_models.generators.v3.paged_attention.generator.MLPerfSubmissionGenerator,
+    furiosa_llm_models.gptj.symbolic.mlperf_submission.GPTJForCausalLM : furiosa_llm_models.generators.paged_attention_optimized_generator_beam_search_optimized.PagedAttentionGeneratorBeamSearch,
     # furiosa_llm_models.gptj.symbolic.preallocated_concat_rope.GPTJForCausalLM : furiosa_llm_models.generators.symbolic.quant_preallocated_concat_generator.QuantPreAllocatedConcatGenerator,
     furiosa_llm_models.gptj.symbolic.paged_attention_rope.GPTJForCausalLM: furiosa_llm_models.generators.symbolic.quant_paged_attention_generator.QuantPagedAttentionGenerator,
     # furiosa_llm_models.gptj.symbolic.paged_attention_optimized_packed_rope.GPTJForCausalLM: furiosa_llm_models.generators.paged_attention_optimized_generator_beam_search.PagedAttentionGeneratorBeamSearch,
@@ -278,13 +278,11 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
 
         if model_type in FURIOSA_GENERATOR_DICT.keys():
             generator = FURIOSA_GENERATOR_DICT[model_type]
-            # if generator == furiosa_llm_models.generators.symbolic.quant_preallocated_concat_generator.QuantPreAllocatedConcatGenerator:
-            #     return generator(quant_causallm, bucket_size = 2048)
-            if generator == furiosa_llm_models.generators.v3.paged_attention.generator.MLPerfSubmissionGenerator:
+            if generator == furiosa_llm_models.generators.symbolic.quant_preallocated_concat_generator.QuantPreAllocatedConcatGenerator:
+                return generator(quant_causallm, bucket_size = 2048)
                 quant_models["prefill_model"].concrete_args = concrete_args["prefill_concrete_args"]
                 quant_models["decode_model"].concrete_args = concrete_args["decode_concrete_args"]
-                #return generator(prefill=quant_models["prefill_model"], decode=quant_models["decode_model"], kv_dtype=torch.int8)
-                return generator(quant_models)
+                return generator(prefill=quant_models["prefill_model"], decode=quant_models["decode_model"], kv_dtype=torch.int8)
             else:                
                 quant_causallm = model_compressor.helper.QuantCausalLM(quant_models, model_type)
                 bucket_size, total_block_space = get_total_block_space(prefill_model.config, kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16')


### PR DESCRIPTION
## 문제상황
- MLPerf submission model로 full model & full calibration 수행시 OOM 발생
- v3.11에서 paged_attenttion calib dataloader를 model forward전에 GPU에 항상 옮겨놨었는데, 이로 인하여 calibration for loop에서 gpu에 total block space 2개가 복사되는 시점이 발생해서 OOM이 발생함

## 목적(해결방향)
- num_blocks를 줄임

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- Dataloader_for_paged_attention에서는 모든 dataset이 하나의 kv_cache block을 공유하기 떄문에, n번째 calibration forward시 생성된 KV_cache block이 n+1번째 calibratio forward시 영향을 줄 수 있음
- 이 현상을 방지하기 위하여 empty_cache 정의 


## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

