### PR TITLE
int8xint8 lm_head dtype for gptj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ generated/
 language/gpt-j/build
 language/gpt-j/quantization/output
 language/gpt-j/model
+mlperf/

--- a/language/gpt-j/quantization/get_quant_model.py
+++ b/language/gpt-j/quantization/get_quant_model.py
@@ -139,7 +139,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
             target_machine=model_script["target_machine"],
             act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
             dataloader=calib_dataloader,
-            disable_inout=(True, True),
+            disable_inout=(True, False),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
         )
 
@@ -174,7 +174,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
                 act_dtype=model_script["act_dtype"],
                 act_nbits=model_script["act_nbits"],
                 kv_dtype=model_script["kv_dtype"] if  "kv_dtype" in model_script else 'bf16',
-                disable_inout=(True, True),
+                disable_inout=(True, False),
             )
 
 
@@ -200,7 +200,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
             target_machine=model_script["target_machine"],
             act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
             dataloader=None,
-            disable_inout=(True, True),
+            disable_inout=(True, False),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
             delete_org_weight=True,
         )
@@ -238,7 +238,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
             target_machine=model_script["target_machine"],
             act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
             dataloader=None,
-            disable_inout=(True, True),
+            disable_inout=(True, False),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
             # decode_phase = True,
             delete_org_weight=True,
@@ -261,7 +261,7 @@ def get_quant_model(model, calib_dataset_path, model_script_path, calib_without_
             target_machine=model_script["target_machine"],
             act_zp_equalizing=(model_script["act_zp_equalizing"] if model_script["act_zp_equalizing"] else 'disabled'),
             dataloader=None,
-            disable_inout=(True, True),
+            disable_inout=(True, False),
             kv_dtype = model_script["kv_dtype"] if "kv_dtype" in model_script else 'bf16',
             decode_phase = True,
             delete_org_weight=True,


### PR DESCRIPTION
## 문제상황
- 컴파일러팀 [요청](https://furiosa-ai.slack.com/archives/C03PPKEGYUC/p1718953673909319?thread_ts=1718883103.786349&cid=C03PPKEGYUC)으로 lm_head int8xint8 로 변경 필요
## 목적(해결방향)

## 구현 설명 Abstract
- lm_head int8xint8 로 변경되도록 disable_inout =[True, True] 에서 [True, False] 로 변경함


## 구현 설명 Detail (ex. 추가된 argument)
-  lm_head int8xint8 로 변경되도록 disable_inout =[True, True] 에서 [True, False] 로 변경함
- golden model relative accuracy 99.9% 를 유지함을 [확인](https://furiosa-ai.slack.com/archives/C05DK2P1LH0/p1719539948844309?thread_ts=1719324862.465399&cid=C05DK2P1LH0) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

