### PR TITLE
control weighted op emul dtype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ generated/
 aws/
 env_mlperf/
 logs/qllama2-70b/
+language/llama2-70b/run_outputs/

--- a/language/llama2-70b/main_ci.py
+++ b/language/llama2-70b/main_ci.py
@@ -176,6 +176,7 @@ def get_args():
                  ], 
         help="choose model source"
     )
+    parser.add_argument("--weighted_op_emul_dtype", type=str, default="fp64", help="set emulation type of weighted operators")
     args = parser.parse_args()
     return args
 

--- a/language/llama2-70b/quantization/get_quant_model.py
+++ b/language/llama2-70b/quantization/get_quant_model.py
@@ -86,7 +86,7 @@ def get_quant_model(model, args, immigrate_qparams=False):
         qlevel=quant_config["qlevel"],
         target_machine=quant_config["target_machine"],
         delete_org_weight=True,
-        weighted_op_emul_dtype='fp32',
+        weighted_op_emul_dtype=args.weighted_op_emul_dtype,
         immigrate_qparams=immigrate_qparams,
     )
 
@@ -99,7 +99,7 @@ def get_quant_model(model, args, immigrate_qparams=False):
         decode_phase=True,
         quantized_prefill_model=prefill_quantized_model,
         delete_org_weight=True,
-        weighted_op_emul_dtype='fp32',
+        weighted_op_emul_dtype=args.weighted_op_emul_dtype,
         immigrate_qparams=immigrate_qparams,
     )
 


### PR DESCRIPTION
## 문제상황
- weighted_op_emul_dtype 가 fp32 로 hard coding 되어있어 main_ci.py (forward ci) 에서 오류가 발생함

## 목적(해결방향)
- weighted_op_emul_dtype 를 입력받아 사용해서 main 은 fp32 로 동작하고 main_ci 는 fp64 로 동작하게 변경

## 구현 설명 Abstract
- weighted_op_emul_dtype 를 입력받아 사용해서 main 은 fp32 로 동작하고 main_ci 는 fp64 로 동작하게 변경


## 구현 설명 Detail (ex. 추가된 argument)
- weighted_op_emul_dtype 를 입력받아 사용해서 main 은 fp32 로 동작하고 main_ci 는 fp64 로 동작하게 변경

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

