### PR TITLE
add args and statedict

### DIFF
--- a/language/llama2-70b/save_qlv4_statedict.py
+++ b/language/llama2-70b/save_qlv4_statedict.py
@@ -62,7 +62,7 @@ def get_args():
         "--qlv4_decode_output_path", help="quantization specifications for calibrated layers"
     )
     parser.add_argument("--quant_config_path", help="a config for model quantization")
-
+    parser.add_argument("--weighted_op_emul_dtype", type=str, default="fp32", help="set emulation type of weighted operators")
     parser.add_argument(
         "--n_layers", 
         type=int, 
@@ -94,11 +94,11 @@ def save_qlv4_model_statdict():
     model = load_pytorch_model(args.model_source, args.model_path, args.n_layers)
     qlv4_model = get_quant_model(model, args)
     if args.model_source == "mlperf_submission":
-        torch.save(qlv4_model.prefill, args.qlv4_prefill_output_path)
-        torch.save(qlv4_model.decode, args.qlv4_decode_output_path)
+        torch.save(qlv4_model.prefill.state_dict(), args.qlv4_prefill_output_path)
+        torch.save(qlv4_model.decode.state_dict(), args.qlv4_decode_output_path)
     else:
-        torch.save(qlv4_model.prefill_model, args.qlv4_prefill_output_path)
-        torch.save(qlv4_model.decode_model, args.qlv4_decode_output_path)
+        torch.save(qlv4_model.prefill_model.state_dict(), args.qlv4_prefill_output_path)
+        torch.save(qlv4_model.decode_model.state_dict(), args.qlv4_decode_output_path)
     
     print(f"qlevel4 prefill state dict saved in {args.qlv4_prefill_output_path}\n")
     print(f"qlevel4 decode state dict saved in {args.qlv4_decode_output_path}\n")


### PR DESCRIPTION
## 문제상황
- 

## 목적(해결방향)
- weighted op emul_dtype args추가
- state_dict명시

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

