### PR TITLE
qlv4_save 수정: handling compact_causal_mask and change default values

### DIFF
--- a/language/bert/qlv4_save.py
+++ b/language/bert/qlv4_save.py
@@ -118,7 +118,7 @@ def get_args():
         choices=[
             "huggingface_rngd_gelu",
             "mlperf_submission",
-            "experimental_huggingface_unsplit_packed",
+            "compact_causal_mask",
         ],
         help="choose model source",
     )
@@ -151,12 +151,12 @@ def qlv4_save():
     sut = None
     args.backend = "pytorch"
     args.max_examples = 1
-    args.recalibrate = True
+    args.recalibrate = False
     args.use_mcp = True
     args.accuracy = True
     args.torch_optim = "none"
     args.model_script_path = (
-        "./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ.yaml"
+        "./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ_submission.yaml"
     )
 
     from pytorch_SUT import get_pytorch_sut
@@ -174,7 +174,7 @@ def qlv4_save():
         output_path=args.output_path,
     )
 
-    if args.model_source =="mlperf_submission":
+    if args.model_source =="mlperf_submission" or args.model_source =="compact_causal_mask" :
         model = sut.model.model
     else:
         model= sut.model

--- a/language/gpt-j/qlv4_save.py
+++ b/language/gpt-j/qlv4_save.py
@@ -12,6 +12,7 @@ model_source="mlperf_submission"
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_path", default="./model/", help="")
+    parser.add_argument("--model_config", default="./ci_test_file/config.json", help="")
     parser.add_argument("--model_script_path", default="./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ-rope_lm-headint8.yaml", help="")
     parser.add_argument("--model_source", type = str, default = "mlperf_submission", help="the type of GPTJForCausalLM to use")
     parser.add_argument('--qformat_path', type = str, default=f'./quantization/output/{version}/{model_source}/qformat.yaml', help="")
@@ -37,7 +38,7 @@ def save_qlv4_model():
         from furiosa_llm_models.gptj.symbolic.mlperf_submission import GPTJForCausalLM
     else:
         raise ValueError("other models are not considered.")
-    config = AutoConfig.from_pretrained(args.model_path)
+    config = AutoConfig.from_pretrained(args.model_config)
     model = GPTJForCausalLM.from_pretrained(args.model_path, config=config).to(device)
     
     model_generator = quantization.get_quant_model(model = model, 

--- a/language/gpt-j/qlv4_save.py
+++ b/language/gpt-j/qlv4_save.py
@@ -7,16 +7,17 @@ import model_compressor
 import joblib
 import argparse
 
+version='v3.12.1'
+model_source="mlperf_submission"
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_path", default="./model/", help="")
-    parser.add_argument("--model_config", default="./ci_test_file/config.json", help="")
     parser.add_argument("--model_script_path", default="./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ-rope_lm-headint8.yaml", help="")
     parser.add_argument("--model_source", type = str, default = "mlperf_submission", help="the type of GPTJForCausalLM to use")
-    parser.add_argument('--qformat_path', type = str, default="./quantization/output/qformat_Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ-mlperf_submission.yaml", help="")
-    parser.add_argument('--qparam_path', type = str, default="./quantization/output/qparam_Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ-mlperf_submission.npy", help="")
-    parser.add_argument('--qlv4_prefill_out_path', type = str, default='./quantization/model_script/prefill.bin', help="")
-    parser.add_argument('--qlv4_decode_out_path', type = str, default='./quantization/model_script/decode.bin', help="")
+    parser.add_argument('--qformat_path', type = str, default=f'./quantization/output/{version}/{model_source}/qformat.yaml', help="")
+    parser.add_argument('--qparam_path', type = str, default=f'./quantization/output/{version}/{model_source}/qparam.npy', help="")
+    parser.add_argument('--qlv4_prefill_out_path', type = str, default=f'./quantization/output/{version}/{model_source}/prefill.bin', help="")
+    parser.add_argument('--qlv4_decode_out_path', type = str, default=f'./quantization/output/{version}/{model_source}/decode.bin', help="")
     args = parser.parse_args()
     return args
     
@@ -36,7 +37,7 @@ def save_qlv4_model():
         from furiosa_llm_models.gptj.symbolic.mlperf_submission import GPTJForCausalLM
     else:
         raise ValueError("other models are not considered.")
-    config = AutoConfig.from_pretrained(args.model_config)
+    config = AutoConfig.from_pretrained(args.model_path)
     model = GPTJForCausalLM.from_pretrained(args.model_path, config=config).to(device)
     
     model_generator = quantization.get_quant_model(model = model, 


### PR DESCRIPTION
## 문제상황
- compact_causal_mask 로 수행 시 문제 발생
- 일부 default 값을 사용 편의로 변경함

## 목적(해결방향)
- compact_causal_mask model_source 이름 맞추지 않아서 SUT 에서 발생하는 오류 해결
- 일부 default 값을 사용 편의로 변경함

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

