### PR TITLE
add smq calibration to llama

### DIFF
--- a/language/llama2-70b/quantization/autoscale/__init__.py
+++ b/language/llama2-70b/quantization/autoscale/__init__.py
@@ -1,0 +1,3 @@
+from .extract_kwargs import *
+from .model_dict import *
+from .transforms_descriptor_utils import *

--- a/language/llama2-70b/quantization/autoscale/extract_kwargs.py
+++ b/language/llama2-70b/quantization/autoscale/extract_kwargs.py
@@ -1,0 +1,127 @@
+import gc
+import json
+import logging
+from typing import Any, Dict
+
+import model_compressor
+import torch
+import furiosa_llm_models 
+from .transforms_descriptor_utils import load_predefined_settings
+from transformers.models.bloom.modeling_bloom import BloomBlock, BloomForCausalLM
+from transformers.models.gptj.modeling_gptj import GPTJAttention, GPTJForCausalLM
+from transformers.models.opt.modeling_opt import OPTAttention, OPTForCausalLM
+from transformers.models.bert.modeling_bert import BertForQuestionAnswering
+from .model_dict import LlamaForCausalLM_dict
+
+__all__ = ["get_autoscale_calib_cfg"]
+
+logger = logging.getLogger(__name__)
+
+
+
+def get_autoscale_calib_cfg(
+    model: torch.nn.Module, autoscale='SmoothQuant', smoothquant_alpha=0.5,
+) -> Dict[str, Any]:
+    logger.info("Prepare autoscale calibration. Get_autoscale_calib_cfg.")
+
+    calib_cfg = {}
+    nodes_excluded_from_auto_scale_calib = ''
+    nodes_excluded_from_auto_clip_calib = ''
+
+    (
+        graph_preprocessor,
+        graph_postprocessor,
+    ) = load_predefined_settings(
+        model, autoscale, if_outlier_compensated=False
+    )
+    calib_cfg['graph_transform_descriptor'] = (graph_preprocessor, graph_postprocessor)
+    calib_cfg['proxy_target_infos'] = []
+
+    if autoscale == 'SmoothQuant':
+        calib_cfg['alpha'] = smoothquant_alpha
+    else:
+        raise NotImplementedError("Other autscales are not implemented.")
+
+    def is_empty(_list):
+        return not bool(_list)
+
+    if is_empty(nodes_excluded_from_auto_scale_calib):
+        nodes_excluded_from_auto_scale_calib = _get_predefined_excluded_from_auto_scale_calib(
+            model, autoscale
+        )
+    calib_cfg['nodes_excluded_from_auto_scale_calib'] = nodes_excluded_from_auto_scale_calib
+
+    if is_empty(nodes_excluded_from_auto_clip_calib):
+        nodes_excluded_from_auto_clip_calib = _get_predefined_excluded_from_auto_clip_calib(
+            model
+        )
+    calib_cfg['nodes_excluded_from_auto_clip_calib'] = nodes_excluded_from_auto_clip_calib
+
+    calib_cfg['unify_smooth_factor'] = False # unify_smooth_factor is implemented only for GPT-J at the moment.
+    calib_cfg['module_name_to_replace_smooth_factor'] = 'fc_in'
+    calib_cfg['module_name_for_smooth_factor'] = 'q_proj'
+
+    return calib_cfg
+
+
+def _get_predefined_excluded_from_auto_scale_calib(torch_model, autoscale):
+
+    if type(torch_model) in LlamaForCausalLM_dict.keys():
+        # Todo - need to check
+        if autoscale == 'AWQ':
+            nodes_list = ["lm_head"]
+        elif autoscale == 'SmoothQuant':
+            nodes_list = ["o_proj", "down_proj", "lm_head"]
+    elif isinstance(torch_model, OPTForCausalLM):
+        if autoscale == 'AWQ':
+            nodes_list = ["lm_head"]
+        elif autoscale == 'SmoothQuant':
+            nodes_list = ['out_proj', 'fc2', 'lm_head']
+    elif isinstance(torch_model, BloomForCausalLM):
+        if autoscale == 'AWQ':
+            nodes_list = ["dense"]
+        elif autoscale == 'SmoothQuant':
+            nodes_list = ['dense', 'dense_4h_to_h']
+    elif isinstance(torch_model, GPTJForCausalLM):
+        if autoscale == 'AWQ':
+            nodes_list = ["lm_head"]
+        elif autoscale == 'SmoothQuant':
+            nodes_list = ['out_proj', 'fc_out', 'lm_head']
+    elif isinstance(torch_model, BertForQuestionAnswering):
+        if autoscale == 'AWQ':
+            nodes_list = ["qa_outputs"]
+        elif autoscale == 'SmoothQuant':
+            nodes_list = ['output.dense', 'output_dense', 'qa_outputs']
+
+    elif "mpt" in str(torch_model.__class__).lower():
+        nodes_list = []
+    elif "falcon" in str(torch_model.__class__).lower():
+        nodes_list = []
+    else:
+        logger.warning(
+            "There is no predefined nodes_excluded_from_auto_scale_calib. Autoscale is applied for all linear nodes."
+        )
+        nodes_list = []
+
+    return nodes_list
+
+
+def _get_predefined_excluded_from_auto_clip_calib(torch_model):
+    if type(torch_model) in LlamaForCausalLM_dict.keys():
+        nodes_list = ['q_proj', 'k_proj', 'lm_head']
+    elif isinstance(torch_model, OPTForCausalLM):
+        nodes_list = ['q_proj', 'k_proj', 'lm_head']
+    elif isinstance(torch_model, BloomForCausalLM):
+        nodes_list = ['query_key_value']
+    elif isinstance(torch_model, GPTJForCausalLM):
+        nodes_list = ['q_proj', 'k_proj', 'lm_head']
+    elif "mpt" in str(torch_model.__class__).lower():
+        nodes_list = []
+    elif "falcon" in str(torch_model.__class__).lower():
+        nodes_list = []
+    else:
+        logger.warning(
+            "There is no predefined nodes_excluded_from_auto_clip_calib. Autoclip is applied for all linear nodes."
+        )
+        nodes_list = ["classifier"]
+    return nodes_list

--- a/language/llama2-70b/quantization/autoscale/model_dict.py
+++ b/language/llama2-70b/quantization/autoscale/model_dict.py
@@ -1,0 +1,12 @@
+import transformers
+import furiosa_llm_models
+
+
+#To DO: Add dictionaries for other models in furiosa-llm-models
+
+LlamaForCausalLM_dict = {
+    transformers.models.llama.modeling_llama.LlamaForCausalLM : transformers.models.llama.modeling_llama,
+    furiosa_llm_models.llama.symbolic.huggingface.LlamaForCausalLM: furiosa_llm_models.llama.symbolic.huggingface,
+    furiosa_llm_models.llama.symbolic.huggingface_rope.LlamaForCausalLM: furiosa_llm_models.llama.symbolic.huggingface_rope,
+    furiosa_llm_models.llama.symbolic.mlperf_submission.LlamaForCausalLM: furiosa_llm_models.llama.symbolic.mlperf_submission,
+}

--- a/language/llama2-70b/quantization/autoscale/transforms_descriptor_utils.py
+++ b/language/llama2-70b/quantization/autoscale/transforms_descriptor_utils.py
@@ -1,0 +1,240 @@
+import json
+import logging
+
+import torch
+from .model_dict import LlamaForCausalLM_dict
+
+__all__ = ["create_descriptor_from_args", "load_predefined_settings"]
+
+logger = logging.getLogger(__name__)
+
+
+def _define_transform_descriptor_from_model_type(
+    model=None,
+    autoscale=None,
+    if_autoscale_preprocessor=True,
+    if_outlier_compensated=False,
+    init_dict_with={},
+):
+    from transformers.models.bloom.modeling_bloom import BloomForCausalLM
+    from transformers.models.opt.modeling_opt import OPTForCausalLM
+    from transformers.models.bert.modeling_bert import BertForQuestionAnswering
+    from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
+
+
+    if_autoscale_postprocessor = not if_autoscale_preprocessor
+    transform_descriptor = []
+    # define transform descriptor according to model instance for autoscale or autoclip
+    if (
+        isinstance(model, OPTForCausalLM)
+        or type(model) in  LlamaForCausalLM_dict.keys()
+        or isinstance(model, GPTJForCausalLM)
+    ):
+        if isinstance(model, OPTForCausalLM):
+            _model_type = 'OPTForCausalLM'
+        elif type(model) in  LlamaForCausalLM_dict.keys():
+            _model_type = 'LlamaForCausalLM'
+        elif isinstance(model, GPTJForCausalLM):
+            _model_type = 'GPTJForCausalLM'
+
+        if if_autoscale_preprocessor:
+            transform_descriptor.extend(
+                [
+                    {
+                        'model_type': _model_type,
+                        'method': 'qkv_integration',
+                        'nodes_to_replace': ['q_proj', 'k_proj', 'v_proj'],
+                        'new_nodes_to_create': ['q_proj'],
+                    }
+                ]
+            )
+
+        elif if_autoscale_postprocessor:
+            if if_outlier_compensated:
+                _method = 'qkv_seperation_with_outlier_module'
+            else:
+                _method = 'qkv_seperation'
+
+            transform_descriptor.extend(
+                [
+                    {
+                        'model_type': _model_type,
+                        'method': _method,
+                        'nodes_to_replace': ['q_proj'],
+                        'new_nodes_to_create': ['q_proj', 'k_proj', 'v_proj'],
+                    }
+                ]
+            )
+
+    elif isinstance(model, BloomForCausalLM):
+        if if_autoscale_preprocessor:
+            pass
+        elif if_autoscale_postprocessor:
+            pass
+    elif isinstance(model, BertForQuestionAnswering):
+        if if_autoscale_preprocessor:
+            transform_descriptor.extend(
+                [
+                    {
+                        'model_type': 'BertForQuestionAnswering',
+                        'method': 'qkv_integration',
+                        'nodes_to_replace': ['query', 'key', 'value'],
+                        'new_nodes_to_create': ['query'],
+                    }
+                ]
+            )
+
+        elif if_autoscale_postprocessor:
+            if if_outlier_compensated:
+                _method = 'qkv_seperation_with_outlier_module'
+            else:
+                _method = 'qkv_seperation'
+
+            transform_descriptor.extend(
+                [
+                    {
+                        'model_type':'BertForQuestionAnswering',
+                        'method': _method,
+                        'nodes_to_replace': ['query'],
+                        'new_nodes_to_create': ['query', 'key', 'value'],
+                    }
+                ]
+            ) 
+    else:
+        raise NotImplementedError(type(model))
+
+    for update_key, update_value in init_dict_with.items():
+        [
+            trs_desc.update({update_key: update_value})
+            for trs_desc in transform_descriptor
+            if update_key in trs_desc.keys()
+        ]
+
+    return transform_descriptor
+
+
+def _define_transform_descriptor_from_method(transform_method=None, init_dict_with={}):
+    # define transform descriptor according to transform_method
+
+    if transform_method == 'qkv_integration':
+        transform_descriptor = {
+            'method': 'qkv_integration',
+            'nodes_to_replace': ['q_proj', 'k_proj', 'v_proj'],
+            'new_nodes_to_create': ['q_proj'],
+        }
+    elif transform_method == 'qkv_seperation':
+        transform_descriptor = {
+            'method': 'qkv_seperation',
+            'nodes_to_replace': ['q_proj'],
+            'new_nodes_to_create': ['q_proj', 'k_proj', 'v_proj'],
+        }
+    elif transform_method == 'qkv_seperation_with_outlier_module':
+        transform_descriptor = {
+            'method': 'qkv_seperation_with_outlier_module',
+            'nodes_to_replace': ['q_proj'],
+            'new_nodes_to_create': ['q_proj', 'k_proj', 'v_proj'],
+        }
+    elif transform_method == 'set_proxy_target':
+        transform_descriptor = {
+            'method': 'set_proxy_target',
+            'module2inspect': [],
+            'layers2inspect': [],
+            'nodes_using_proxy_target': [],
+            'layer_kwargs': {},
+        }
+    else:
+        raise NotImplementedError(transform_method)
+
+    for update_key, update_value in init_dict_with.items():
+        transform_descriptor.update({update_key: update_value})
+
+    return transform_descriptor
+
+
+def load_predefined_settings(
+    model: torch.nn.Module, autoscale, if_outlier_compensated=False
+):
+    from transformers.models.bloom.modeling_bloom import BloomForCausalLM
+    from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
+    from transformers.models.opt.modeling_opt import OPTForCausalLM
+    from transformers.models.bert.modeling_bert import BertForQuestionAnswering
+    
+    preprocessor = []
+    postprocessor = []
+
+    if (
+        isinstance(model, OPTForCausalLM)
+        or type(model) in  LlamaForCausalLM_dict.keys()
+        or isinstance(model, BertForQuestionAnswering)
+        or isinstance(model, GPTJForCausalLM)
+    ):
+        preprocessor.extend(
+            _define_transform_descriptor_from_model_type(
+                model, autoscale, if_autoscale_preprocessor=True
+            )
+        )
+        postprocessor.extend(
+            _define_transform_descriptor_from_model_type(
+                model,
+                if_autoscale_preprocessor=False,
+                if_outlier_compensated=if_outlier_compensated,
+            )
+        )
+
+    elif isinstance(model, BloomForCausalLM):
+        pass
+
+    else:
+        logger.warning(f'There is no predefined graph processor for {type(model)}')
+
+    return preprocessor, postprocessor
+
+
+def create_descriptor_from_args(autoscale, customized_model_node_kwargs_json_path):
+    """
+    Only implemented for qkv node seperation/integration transform
+    """
+
+    preprocessor = []
+    postprocessor = []
+
+    with open(customized_model_node_kwargs_json_path, encoding="utf-8") as f:
+        try:
+            customized_model_node_kwargs = json.loads(f.read())
+        except Exception as e:
+            print(e, f"Invalid json file. {customized_model_node_kwargs_json_path}")
+
+    qkv_node_name = [
+        customized_model_node_kwargs.pop('q_node', None),
+        customized_model_node_kwargs.pop('k_node', None),
+        customized_model_node_kwargs.pop('v_node', None),
+    ]
+
+    if not all([name is not None for name in qkv_node_name]):
+        raise ValueError("Invalid q, k, v node name. Check args.customized_model_node_kwargs.")
+
+    if autoscale == 'AWQ':
+        qkv_node_suffix = [node_name.split('.')[-1] for node_name in qkv_node_name]
+        if len(qkv_node_suffix) > 1:
+            # Need to integrate qkv for autoscale. Preprocessor will redefine integrated linear node at qkv_node_suffix[0].
+
+            preprocessor.append(
+                _define_transform_descriptor_from_method(
+                    'qkv_integration',
+                    {
+                        'nodes_to_replace': qkv_node_suffix,
+                        'new_nodes_to_create': [qkv_node_suffix[0]],
+                    },
+                )
+            )
+            postprocessor.append(
+                _define_transform_descriptor_from_method(
+                    'qkv_seperation',
+                    {
+                        'nodes_to_replace': [qkv_node_suffix[0]],
+                        'new_nodes_to_create': qkv_node_suffix,
+                    },
+                )
+            )
+
+    return preprocessor, postprocessor


### PR DESCRIPTION
## 문제상황
- 

## 목적(해결방향)
- llama에서 smq가 가능하도록 calibration 코드 수정

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

