### PR TITLE
Fix smq calibrate

### DIFF
--- a/language/llama2-70b/quantization/autoscale/extract_kwargs.py
+++ b/language/llama2-70b/quantization/autoscale/extract_kwargs.py
@@ -60,6 +60,7 @@ def get_autoscale_calib_cfg(
     calib_cfg['unify_smooth_factor'] = False # unify_smooth_factor is implemented only for GPT-J at the moment.
     calib_cfg['module_name_to_replace_smooth_factor'] = 'fc_in'
     calib_cfg['module_name_for_smooth_factor'] = 'q_proj'
+    calib_cfg['nodes_excluded_from_auto_scale_calib'].extend(['gate_proj', 'up_proj'])
 
     return calib_cfg
 

--- a/language/llama2-70b/quantization/calibrate.py
+++ b/language/llama2-70b/quantization/calibrate.py
@@ -99,6 +99,12 @@ def get_autoscale_calib_config(model, autoscale, smoothquant_alpha):
 
 
 def calibrate(model, model_source, qconfig, qparam_path, qformat_path, calib_dataloader):
+    if 'autoscale' in qconfig:
+        smoothquant_alpha = qconfig.get("smoothquant_alpha", 0.5)
+        autoscale_calib_kwargs = get_autoscale_calib_config(model, autoscale=qconfig["autoscale"], smoothquant_alpha=smoothquant_alpha)
+    else:
+        autoscale_calib_kwargs = None
+    
     if model_source == 'mlperf_submission':
         model = model.trace_prefill()
     else:
@@ -115,11 +121,6 @@ def calibrate(model, model_source, qconfig, qparam_path, qformat_path, calib_dat
         **get_kwargs(model_compressor.create_quantsim_model, qconfig),
     )
 
-    if 'autoscale' in qconfig:
-        smoothquant_alpha = qconfig.get("smoothquant_alpha", 0.5)
-        autoscale_calib_kwargs = get_autoscale_calib_config(model, autoscale=qconfig["autoscale"], smoothquant_alpha=smoothquant_alpha)
-    else:
-        autoscale_calib_kwargs = None
     model_compressor.calibrate(
         model,
         calib_dataloader=calib_dataloader,


### PR DESCRIPTION
## 문제상황
- qkv가 한개로 합쳐지지 않고 SMQ가 적용되고 있음
- up_proj와 gate에 대해 integrate가 되지 않아,각각에 quantizer가 생성되고 있음

## 목적(해결방향)
- autoscale kwargs를 추출하는 부분이 torch model을 받도록 위치 변경
- up_proj와 gate를 SMQ적용대상에서 제외

## 구현 설명 Abstract
-


## 구현 설명 Detail (ex. 추가된 argument)
- cnn_eval_accuracy_ci를 통해서 그래프 분리 기능 및 furiosa-llm이 정상작동하는걸 확인 (tokenwise로 combined graph + transformers == separated graphs + transformers == separated graphs + furiosa_llm_original 인 것을 확인) 

## test 통과 내역 (CI 통과내역과 어떤 machine (GPU pod or NPU machien or local)에서 테스트했는지)
- [ ] local machine with 3090
- [ ] GPU pod
- [ ] warboy pod
  - `"python main.py --scenario Offline --model-path ./model/ --dataset-path ./data/cnn_eval_accuracy_ci.json --model_script_path ./quantization/model_script/Qlevel4_RGDA0-W8A8KV8-PTQ-SMQ.yaml --gpu --accuracy --use_mcp --calib-dataset-path ./data/cnn_dailymail_calibration.json --recalibrate --model_source [transformers or furiosa_llm_original]"

## TODO (ex. 후속PR예고)
- 

